### PR TITLE
use github graphql for query batching & fix bad contribution logs

### DIFF
--- a/.github/workflows/daily-runner.yml
+++ b/.github/workflows/daily-runner.yml
@@ -24,12 +24,10 @@ jobs:
           bundler-cache: true
           
       - name: Install dependencies
-        run: |
-          gem install octokit
-          gem install fileutils
+        run: bundle install
         
       - name: Run contribution tracker
-        run: ruby contributions.rb
+        run: ruby contributions_graphql.rb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/contributions_graphql.rb
+++ b/contributions_graphql.rb
@@ -1,0 +1,377 @@
+
+require 'octokit'
+require 'fileutils'
+require 'set'
+require 'date'
+require 'json'
+require 'net/http'
+require 'uri'
+
+TIME_PERIOD = 24 * 60 * 60 # 24 hours default
+
+class GithubGraphQLClient
+  GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql'
+  REPO_BATCH_SIZE = 3
+
+  def initialize(token)
+    @token = token
+    @rest_client = Octokit::Client.new(access_token: token)
+    @rest_client.auto_paginate = false
+  end
+
+  def graphql(query, variables = {})
+    uri = URI(GITHUB_GRAPHQL_URL)
+    request = Net::HTTP::Post.new(uri)
+    request['Authorization'] = "bearer #{@token}"
+    request['Content-Type'] = 'application/json'
+    request.body = JSON.generate({ query: query, variables: variables })
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    if response.code.to_i == 403 || response.code.to_i == 429
+      puts "Rate limited (#{response.code}), waiting 60s..."
+      sleep 60
+      return graphql(query, variables)
+    end
+
+    unless response.content_type&.include?('json')
+      puts "Non-JSON response (#{response.code}), waiting 30s and retrying..."
+      sleep 30
+      return graphql(query, variables)
+    end
+
+    result = JSON.parse(response.body)
+    if result['errors']
+      puts "GraphQL errors: #{result['errors'].map { |e| e['message'] }.join(', ')}"
+    end
+    result['data']
+  end
+
+  def get_org_repos(org, count: 50)
+    repos = @rest_client.organization_repositories(org, sort: 'pushed', per_page: count)
+    repos.map { |r| r.full_name }
+  end
+
+  def fetch_repo_contributions(repos, since_time)
+    all_contributions = []
+    since_iso = since_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    repos.each_slice(REPO_BATCH_SIZE) do |batch|
+      query = build_batch_query(batch, since_iso)
+      next if query.nil?
+
+      data = graphql(query)
+      next unless data
+
+      batch.each_with_index do |repo, idx|
+        alias_name = "repo#{idx}"
+        repo_data = data[alias_name]
+        next unless repo_data
+
+        parse_repo_data(repo, repo_data, since_time, all_contributions)
+      end
+    end
+
+    all_contributions
+  end
+
+  private
+
+  def build_batch_query(repos, since_iso)
+    fragments = repos.each_with_index.map do |repo, idx|
+      owner, name = repo.split('/', 2)
+      next nil unless owner && name
+
+      owner_escaped = owner.gsub('"', '\\"')
+      name_escaped = name.gsub('"', '\\"')
+
+      <<~GQL
+        repo#{idx}: repository(owner: "#{owner_escaped}", name: "#{name_escaped}") {
+          pullRequests(first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes {
+              title
+              url
+              author { login }
+              createdAt
+              merged
+              mergedAt
+            }
+          }
+          issues(first: 50, filterBy: {since: "#{since_iso}"}, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes {
+              title
+              url
+              author { login }
+              createdAt
+            }
+          }
+          defaultBranchRef {
+            target {
+              ... on Commit {
+                history(first: 50, since: "#{since_iso}") {
+                  nodes {
+                    message
+                    url
+                    author { user { login } }
+                    committedDate
+                  }
+                }
+              }
+            }
+          }
+        }
+      GQL
+    end.compact
+
+    return nil if fragments.empty?
+    "query {\n#{fragments.join("\n")}\n}"
+  end
+
+  def parse_repo_data(repo, repo_data, since_time, contributions)
+    # Parse pull requests (opened)
+    prs = repo_data.dig('pullRequests', 'nodes') || []
+    prs.each do |pr|
+      next unless pr && pr['author'] && pr['title']
+      created = Time.parse(pr['createdAt'])
+      if created >= since_time
+        contributions << {
+          repo: repo,
+          type: 'Pull Request',
+          title: pr['title'],
+          url: pr['url'],
+          username: pr['author']['login'],
+          timestamp: created
+        }
+      end
+
+      # Parse merged PRs (mergedAt in window, but not opened in window)
+      if pr['merged'] && pr['mergedAt']
+        merged_at = Time.parse(pr['mergedAt'])
+        if merged_at >= since_time && (created < since_time)
+          contributions << {
+            repo: repo,
+            type: 'Pull Request',
+            title: pr['title'],
+            url: pr['url'],
+            username: pr['author']['login'],
+            timestamp: merged_at
+          }
+        end
+      end
+
+      # Reviews not included in batch query to stay within GraphQL resource limits
+    end
+
+    # Parse issues (opened)
+    issues = repo_data.dig('issues', 'nodes') || []
+    issues.each do |issue|
+      next unless issue && issue['author'] && issue['title']
+      created = Time.parse(issue['createdAt'])
+      next unless created >= since_time
+
+      contributions << {
+        repo: repo,
+        type: 'Issue',
+        title: issue['title'],
+        url: issue['url'],
+        username: issue['author']['login'],
+        timestamp: created
+      }
+    end
+
+    # Parse commits
+    commits = repo_data.dig('defaultBranchRef', 'target', 'history', 'nodes') || []
+    commits.each do |commit|
+      next unless commit && commit.dig('author', 'user')
+      committed = Time.parse(commit['committedDate'])
+      next unless committed >= since_time
+
+      message = commit['message'].split("\n").first
+      contributions << {
+        repo: repo,
+        type: 'Commit',
+        title: message,
+        url: commit['url'],
+        username: commit['author']['user']['login'],
+        timestamp: committed
+      }
+    end
+  end
+end
+
+class UserActivityChecker
+  attr_reader :active_users
+
+  def initialize(members_dir, repos)
+    @members_dir = members_dir
+    @repos = repos
+    @active_users = Set.new
+    @contribution_cache = {}
+    @members = Set.new(get_all_members.map(&:downcase))
+  end
+
+  def process_contributions(contributions)
+    contributions.each do |contrib|
+      username = contrib[:username]&.downcase
+      next unless username && is_member?(username)
+
+      @active_users.add(username)
+
+      repo = contrib[:repo]
+      type = contrib[:type]
+      title = contrib[:title]
+      url = contrib[:url]
+      timestamp = contrib[:timestamp]
+
+      next unless title && url
+
+      key = "#{repo}:#{type}:#{url}"
+      next if @contribution_cache[key]
+      @contribution_cache[key] = true
+
+      quarter = get_quarter(timestamp)
+      puts "  ✓ Found #{type} by #{username}: #{title}"
+
+      MemberContribution.new(username, @members_dir)
+        .add_contribution(repo, type, title, url, timestamp, quarter)
+    end
+
+    puts "\nActive users: #{@active_users.size}"
+    puts "Inactive users: #{(@members - @active_users).size}"
+  end
+
+  def is_member?(username)
+    @members.include?(username.downcase)
+  end
+
+  def get_quarter(timestamp)
+    year = timestamp.year
+    month = timestamp.month
+    quarter = ((month - 1) / 3) + 1
+    "Q#{quarter} #{year}"
+  end
+
+  private
+
+  def get_all_members
+    return [] unless Dir.exist?(@members_dir)
+
+    Dir.glob(File.join(@members_dir, "*.md")).map do |file|
+      File.basename(file, ".md")
+    end
+  end
+end
+
+class MemberContribution
+  def initialize(username, members_dir)
+    @username = username
+    @members_dir = members_dir
+    @file_path = File.join(members_dir, "#{username.downcase}.md")
+  end
+
+  def add_contribution(repo, type, title, url, timestamp, quarter)
+    return unless File.exist?(@file_path)
+    content = File.read(@file_path)
+
+    date_str = timestamp.strftime('%Y-%m-%d')
+    contribution_line = "* [#{type}] [#{title}](#{url}) - #{date_str}"
+    return if content.include?(contribution_line)
+
+    quarter_section = "## #{quarter}"
+    if !content.include?(quarter_section)
+      if content.include?("## Contributions")
+        content = content.gsub("## Contributions", "## Contributions\n\n#{quarter_section}")
+      else
+        content += "\n\n#{quarter_section}"
+      end
+    end
+
+    repo_line = "[#{repo}](https://github.com/#{repo})"
+    quarter_pattern = /#{Regexp.escape(quarter_section)}(.*?)(?=^##|\z)/m
+    if content =~ quarter_pattern
+      quarter_content = $1
+
+      if quarter_content.include?(repo_line)
+        content = content.gsub(quarter_pattern) do |match|
+          quarter_text = $1
+          repo_pattern = /#{Regexp.escape(repo_line)}(.*?)(?=^\[|\z)/m
+          quarter_text = quarter_text.gsub(repo_pattern) do |repo_section|
+            repo_content = $1
+            "#{repo_line}#{repo_content}#{contribution_line}\n"
+          end
+          "#{quarter_section}#{quarter_text}"
+        end
+      else
+        content = content.gsub(quarter_pattern) do |match|
+          "#{quarter_section}#{$1}\n#{repo_line}\n#{contribution_line}\n"
+        end
+      end
+    else
+      content += "\n\n#{quarter_section}\n#{repo_line}\n#{contribution_line}\n"
+    end
+
+    File.write(@file_path, content)
+  end
+end
+
+class ContributionTracker
+  def initialize(token, members_dir, repos_file)
+    @client = GithubGraphQLClient.new(token)
+    @members_dir = members_dir
+    repos, orgs = load_entries(repos_file)
+    @repos = repos + resolve_org_repos(orgs)
+    @since_time = Time.now - TIME_PERIOD
+  end
+
+  def track_contributions
+    puts "Fetching contributions since #{@since_time} for #{@repos.size} repos..."
+
+    contributions = @client.fetch_repo_contributions(@repos, @since_time)
+    puts "Found #{contributions.size} total contributions"
+
+    checker = UserActivityChecker.new(@members_dir, @repos)
+    checker.process_contributions(contributions)
+  end
+
+  private
+
+  def load_entries(repos_file)
+    if File.exist?(repos_file)
+      entries = File.readlines(repos_file).map(&:strip).reject(&:empty?)
+      repos = entries.select { |e| e.include?('/') }
+      orgs = entries.reject { |e| e.include?('/') }
+      [repos, orgs]
+    else
+      puts "repos.txt file not found, add list of repos"
+      [[], []]
+    end
+  end
+
+  def resolve_org_repos(orgs)
+    return [] if orgs.empty?
+
+    all_org_repos = []
+    orgs.each do |org|
+      begin
+        puts "Fetching active repositories for organization: #{org}"
+        repos = @client.get_org_repos(org, count: 50)
+        all_org_repos.concat(repos)
+        puts "  Found #{repos.size} active repositories for #{org}"
+      rescue => e
+        puts "Error fetching repos for org #{org}: #{e.message}"
+      end
+    end
+    all_org_repos
+  end
+end
+
+if __FILE__ == $0
+  token = ENV['GITHUB_TOKEN']
+  members_dir = 'members'
+  repos_file = 'repos.txt'
+
+  tracker = ContributionTracker.new(token, members_dir, repos_file)
+  tracker.track_contributions
+end

--- a/contributions_graphql.rb
+++ b/contributions_graphql.rb
@@ -50,8 +50,10 @@ class GithubGraphQLClient
   end
 
   def get_org_repos(org, count: 50)
+    cutoff = Time.now - (7 * 24 * 60 * 60) # 1 week
     repos = @rest_client.organization_repositories(org, sort: 'pushed', per_page: count)
-    repos.map { |r| r.full_name }
+    active = repos.select { |r| r.pushed_at && Time.parse(r.pushed_at.to_s) >= cutoff }
+    active.map { |r| r.full_name }
   end
 
   def fetch_repo_contributions(repos, since_time)
@@ -97,6 +99,13 @@ class GithubGraphQLClient
               createdAt
               merged
               mergedAt
+              reviews(first: 10) {
+                nodes {
+                  author { login }
+                  url
+                  createdAt
+                }
+              }
             }
           }
           issues(first: 50, filterBy: {since: "#{since_iso}"}, orderBy: {field: UPDATED_AT, direction: DESC}) {
@@ -161,7 +170,22 @@ class GithubGraphQLClient
         end
       end
 
-      # Reviews not included in batch query to stay within GraphQL resource limits
+      # Parse reviews on this PR
+      reviews = pr.dig('reviews', 'nodes') || []
+      reviews.each do |review|
+        next unless review && review['author']
+        review_time = Time.parse(review['createdAt'])
+        next unless review_time >= since_time
+
+        contributions << {
+          repo: repo,
+          type: 'Review',
+          title: "Review on: #{pr['title']}",
+          url: review['url'],
+          username: review['author']['login'],
+          timestamp: review_time
+        }
+      end
     end
 
     # Parse issues (opened)

--- a/members/advaita-saha.md
+++ b/members/advaita-saha.md
@@ -12,24 +12,24 @@ Team: [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/pulls?q=a
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [update EEST to v5.4.0](https://github.com/status-im/nimbus-eth1/pull/3894) - 2026-01-05
+* [Pull Request] [getBlobV3 implementation](https://github.com/status-im/nimbus-eth1/pull/3893) - 2026-01-06
 
-* [Pull Request] []() - 2026-01-17
-* [Pull Request] []() - 2026-01-18
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [incorrect rlp import shouldn't close the client](https://github.com/status-im/nimbus-eth1/pull/3921) - 2026-01-17
+* [Pull Request] [incorrect rlp import shouldn't close the client](https://github.com/status-im/nimbus-eth1/pull/3921) - 2026-01-18
+* [Pull Request] [Single binary release](https://github.com/status-im/nimbus-eth1/pull/3966) - 2026-02-04
 * [Issue] [shift release to docker multi-arch](https://github.com/status-im/nimbus-eth1/issues/3972) - 2026-02-10
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-02-21
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [introduce multiarch manifest push in release](https://github.com/status-im/nimbus-eth1/pull/3988) - 2026-02-16
+* [Pull Request] [fix macos docker builds ](https://github.com/status-im/nimbus-eth1/pull/3992) - 2026-02-17
+* [Pull Request] [switch to `Nimbus`  from `NimbusExecutionClient`](https://github.com/status-im/nimbus-eth1/pull/4002) - 2026-02-20
+* [Pull Request] [switch to `Nimbus`  from `NimbusExecutionClient`](https://github.com/status-im/nimbus-eth1/pull/4002) - 2026-02-21
+* [Pull Request] [remove `blk` from BlockRef](https://github.com/status-im/nimbus-eth1/pull/4014) - 2026-02-24
+* [Pull Request] [check for FC corruption while loading](https://github.com/status-im/nimbus-eth1/pull/4023) - 2026-02-26
+* [Pull Request] [Optimize sync memory](https://github.com/status-im/nimbus-eth1/pull/4038) - 2026-03-09
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [clients/nimbus-el: update nimbus rlp import](https://github.com/ethereum/hive/pull/1381) - 2026-01-16
+* [Pull Request] [clients/nimbus-el: update nimbus rlp import](https://github.com/ethereum/hive/pull/1381) - 2026-01-19
+* [Pull Request] [clients/nimbus-el: update nimbus-el to unified client](https://github.com/ethereum/hive/pull/1396) - 2026-03-02
 ## Q4 2025
 
 

--- a/members/agnxsh.md
+++ b/members/agnxsh.md
@@ -11,13 +11,13 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 
 
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-01-03
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-15
-* [Pull Request] []() - 2026-01-21
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-07
+* [Pull Request] [update copyright years for `beacon_chain/*`](https://github.com/status-im/nimbus-eth2/pull/7828) - 2026-01-03
+* [Pull Request] [bump: `nim-web3`](https://github.com/status-im/nimbus-eth2/pull/7839) - 2026-01-09
+* [Pull Request] [add: `engine_getBlobsV3` helpers for cell level dissemination](https://github.com/status-im/nimbus-eth2/pull/7847) - 2026-01-15
+* [Pull Request] [tie `getBlobs` calling with block gossip callback](https://github.com/status-im/nimbus-eth2/pull/7866) - 2026-01-21
+* [Pull Request] [modularise message routing for sidecars](https://github.com/status-im/nimbus-eth2/pull/7751) - 2026-01-22
+* [Pull Request] [add metric to monitor column validation latency](https://github.com/status-im/nimbus-eth2/pull/8056) - 2026-03-04
+* [Pull Request] [update column quarantine, and supernode behaviour](https://github.com/status-im/nimbus-eth2/pull/8061) - 2026-03-07
 ## Q4 2025
 
 
@@ -27,16 +27,16 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Pull Request] [drop vcus backfilling and adjust eas movement](https://github.com/status-im/nimbus-eth2/pull/7601) - 2025-10-11
 * [Commit] [remove unused import](https://github.com/status-im/nimbus-eth2/commit/ff1f6a42c8c5df31528436675966848d580668e6) - 2025-10-12
 * [Pull Request] [prevent vcus from happening in non validating nodes](https://github.com/status-im/nimbus-eth2/pull/7606) - 2025-10-13
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-11
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-18
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [reconstruction timeout + vcus detection on no column sidecars in quarantine](https://github.com/status-im/nimbus-eth2/pull/7610) - 2025-10-14
+* [Pull Request] [add blob limit, in data column sidecar gossip](https://github.com/status-im/nimbus-eth2/pull/7617) - 2025-10-15
+* [Pull Request] [improve `BlobsBundle` abstraction + add fulu preset endpoints](https://github.com/status-im/nimbus-eth2/pull/7709) - 2025-11-04
+* [Pull Request] [drop updating custody count on the last slot of given epoch](https://github.com/status-im/nimbus-eth2/pull/7724) - 2025-11-10
+* [Pull Request] [improve column batch addition from getBlobs](https://github.com/status-im/nimbus-eth2/pull/7725) - 2025-11-11
+* [Pull Request] [fix lsupernode logic](https://github.com/status-im/nimbus-eth2/pull/7763) - 2025-11-28
+* [Pull Request] [fixes for parallel reconstruction](https://github.com/status-im/nimbus-eth2/pull/7758) - 2025-12-08
+* [Pull Request] [fix blob schedule parsing at genesis](https://github.com/status-im/nimbus-eth2/pull/7788) - 2025-12-09
+* [Pull Request] [put appropriate rman log message](https://github.com/status-im/nimbus-eth2/pull/7812) - 2025-12-18
+* [Pull Request] [put appropriate rman log message](https://github.com/status-im/nimbus-eth2/pull/7812) - 2025-12-19
 ## Q3 2025
 
 

--- a/members/ahamlat.md
+++ b/members/ahamlat.md
@@ -18,9 +18,9 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Aah
 * [Issue] [Investigate long limbs on UInt256](https://github.com/hyperledger/besu/issues/9356) - 2025-10-23
 * [Issue] [Address performance improvements comments on UInt246](https://github.com/hyperledger/besu/issues/9355) - 2025-10-23
 * [Issue] [Improve ADD performance using UInt256](https://github.com/hyperledger/besu/issues/9478) - 2025-11-20
-* [Pull Request] []() - 2025-11-20
+* [Pull Request] [Improve Add OpCode performance](https://github.com/besu-eth/besu/pull/9477) - 2025-11-20
 * [Issue] [Implement EVM arithmetic operations using the new UInt256 implementation](https://github.com/hyperledger/besu/issues/9472) - 2025-11-20
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [Optimize performances of AND, OR, XOR and NOT opcodes](https://github.com/besu-eth/besu/pull/9489) - 2025-12-02
 * [Issue] [Reduce memory usage of debug_trace* calls](https://github.com/hyperledger/besu/issues/9584) - 2025-12-18
 ## Q3 2025
 

--- a/members/ak88.md
+++ b/members/ak88.md
@@ -12,8 +12,8 @@ Team: Nethermind
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-15
+* [Pull Request] [SyncInfo decoder for XDC p2p](https://github.com/NethermindEth/nethermind/pull/10509) - 2026-02-13
+* [Pull Request] [Fix XDC gas limit calculation ](https://github.com/NethermindEth/nethermind/pull/10537) - 2026-02-15
 ## Q4 2025
 
 
@@ -30,7 +30,7 @@ Team: Nethermind
 * [Commit] [XDC : QuorumCertificate Manager (#9294)](https://github.com/NethermindEth/nethermind/commit/1a523ec310f0ba9dfc5e6b96dd11255d73c876e0) - 2025-10-06
 * [Commit] [Update src/Nethermind/Nethermind.Xdc/Types/Timeout.cs](https://github.com/NethermindEth/nethermind/commit/207f4e7858de3cd3a30ab703f7ed03ebb4f46270) - 2025-10-07
 * [Commit] [comment](https://github.com/NethermindEth/nethermind/commit/d34a2aa0e77eaafcc90d148bc457851b64b157a2) - 2025-10-08
-* [Pull Request] []() - 2025-12-24
+* [Pull Request] [Feature/xdc genesis nodes](https://github.com/NethermindEth/nethermind/pull/10022) - 2025-12-24
 ## Q3 2025
 
 

--- a/members/anacrolix.md
+++ b/members/anacrolix.md
@@ -10,17 +10,22 @@ Github: [@anacrolix](https://github.com/anacrolix)
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [Vary no metadata yet log level depending on circumstances](https://github.com/erigontech/erigon/pull/18826) - 2026-01-27
+* [Pull Request] [Vary no metadata yet log level depending on circumstances](https://github.com/erigontech/erigon/pull/18826) - 2026-01-29
 * [Issue] [Builds on Windows have confusing warnings](https://github.com/erigontech/erigon/issues/19201) - 2026-02-16
-* [Pull Request] []() - 2026-02-16
+* [Pull Request] [ci: fix test caching, improve workflow structure and test grouping](https://github.com/erigontech/erigon/pull/19223) - 2026-02-16
 * [Issue] [Update ethereum/hive to build erigon with the correct go version](https://github.com/erigontech/erigon/issues/19206) - 2026-02-16
 * [Issue] [Update golanglint-ci to 2.9](https://github.com/erigontech/erigon/issues/19236) - 2026-02-17
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [Update agents.md: remove stale synctest reference, minor cleanups](https://github.com/erigontech/erigon/pull/19415) - 2026-02-23
 * [Issue] [downloader: Adding existing snapshots](https://github.com/erigontech/erigon/issues/19435) - 2026-02-24
-* [Pull Request] []() - 2026-03-07
+* [Pull Request] [downloader: add torrents from disk after snapshot sync stage](https://github.com/erigontech/erigon/pull/19712) - 2026-03-07
 * [Issue] [downloader: extract preverified.toml filters into a reusable, testable function](https://github.com/erigontech/erigon/issues/19718) - 2026-03-07
 * [Issue] [downloader: persist preverified.toml at sync start and write sync-completion marker at end](https://github.com/erigontech/erigon/issues/19717) - 2026-03-07
 * [Issue] [downloader: error on extraneous snapshots when resuming an incomplete sync](https://github.com/erigontech/erigon/issues/19716) - 2026-03-07
 * [Issue] [downloader: record and validate download filters across preverified.toml scans](https://github.com/erigontech/erigon/issues/19715) - 2026-03-07
-* [Issue] [downloader: add preverified source selection (local/remote/embedded) to main erigon node](https://github.com/erigontech/erigon/issues/19714) - 2026-03-07
+* [Issue] [downloader: add preverified source selection (local/remote/embedded) to main erigon node](https://github.com/erigontech/erigon/issues/19714) - 2026-03-07* [Pull Request] [execution/tests: fix state test DB contention](https://github.com/erigontech/erigon/pull/19767) - 2026-03-10
+* [Pull Request] [ci, execution/tests: run MDBX test temp dirs on a RAM disk](https://github.com/erigontech/erigon/pull/19769) - 2026-03-10
+* [Pull Request] [ci, make: add test-bench to verify all benchmarks compile and run](https://github.com/erigontech/erigon/pull/19745) - 2026-03-10
+* [Commit] [ci, make: add test-bench to verify all benchmarks compile and run (#19745)](https://github.com/erigontech/erigon/commit/dfb70d20abfbc499666e7dc0e8ea6fb517700a18) - 2026-03-10
+* [Commit] [ci: fix duplicate types key in lint workflow pull_request trigger (#19770)](https://github.com/erigontech/erigon/commit/352412024c4e8aa75b2a08b4e04a8a33de48fbd7) - 2026-03-10
+* [Commit] [ci: prune Go build cache before saving (#19768)](https://github.com/erigontech/erigon/commit/32c9f818684c1f24a3d5c48513e34d74f01b3481) - 2026-03-10

--- a/members/anderselowsson.md
+++ b/members/anderselowsson.md
@@ -12,18 +12,18 @@ Team: Robust Incentives Group (RIG)
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-03-04
+* [Pull Request] [Add EIP: LUCID encrypted mempool](https://github.com/ethereum/EIPs/pull/11376) - 2026-03-04
 ## Q4 2025
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-16
-* [Pull Request] []() - 2025-10-22
-* [Pull Request] []() - 2025-11-01
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-12-14
+* [Pull Request] [Add EIP: FOCIL with ranked transactions (FOCILR)](https://github.com/ethereum/EIPs/pull/10554) - 2025-10-16
+* [Pull Request] [Update EIP-7773: Removed PFI for EIP-7999](https://github.com/ethereum/EIPs/pull/10590) - 2025-10-22
+* [Pull Request] [Update EIP-8068: Update EIP-8068](https://github.com/ethereum/EIPs/pull/10670) - 2025-11-01
+* [Pull Request] [Update EIP-8062: Added an alternative specification and two figures for illustrating capital efficiency](https://github.com/ethereum/EIPs/pull/10783) - 2025-11-12
+* [Pull Request] [Update EIP-8062: tiny edits](https://github.com/ethereum/EIPs/pull/10785) - 2025-11-13
+* [Pull Request] [Update EIP-8062: Minor edits](https://github.com/ethereum/EIPs/pull/10843) - 2025-11-27
+* [Pull Request] [Update EIP-8046: Rename and update figure](https://github.com/ethereum/EIPs/pull/10919) - 2025-12-14
 ## Q3 2025
 
 

--- a/members/antondlr.md
+++ b/members/antondlr.md
@@ -12,7 +12,7 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aanto
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2025-11-12
+* [Pull Request] [re-targeting of `remove-windows-ci` against `release-v8.0`](https://github.com/sigp/lighthouse/pull/8406) - 2025-11-12
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
 * [Issue] [Tokio panics when calling metrics](https://github.com/paradigmxyz/reth/issues/19986) - 2025-11-26

--- a/members/arnetheduck.md
+++ b/members/arnetheduck.md
@@ -12,39 +12,39 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 
 
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-01
+* [Pull Request] [ForkedHashedBeaconState helpers](https://github.com/status-im/nimbus-eth2/pull/7903) - 2026-01-29
+* [Pull Request] [ForkedHashedBeaconState helpers](https://github.com/status-im/nimbus-eth2/pull/7903) - 2026-01-30
+* [Pull Request] [use `func`s for `getForkedBlockField`](https://github.com/status-im/nimbus-eth2/pull/7907) - 2026-02-01
 
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-22
+* [Pull Request] [clean up attestation index iteration](https://github.com/status-im/nimbus-eth2/pull/7999) - 2026-02-19
+* [Pull Request] [el_manager: update multi-el support](https://github.com/status-im/nimbus-eth2/pull/8008) - 2026-02-22
 * [Issue] [Light client fcU should not spam the EL](https://github.com/status-im/nimbus-eth2/issues/8041) - 2026-02-26
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [web3: bump for native bidir support](https://github.com/status-im/nimbus-eth1/pull/3974) - 2026-02-11
+* [Pull Request] [eth2: bump](https://github.com/status-im/nimbus-eth1/pull/3991) - 2026-02-18
+* [Pull Request] [use eth/trie/nibbles consistently](https://github.com/status-im/nimbus-eth1/pull/4026) - 2026-02-27
+* [Pull Request] [Improve call performance](https://github.com/status-im/nimbus-eth1/pull/4032) - 2026-03-03
+* [Pull Request] [Improve call performance](https://github.com/status-im/nimbus-eth1/pull/4032) - 2026-03-05
 ## Q4 2025
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2025-10-21
+* [Pull Request] [`NimbusConf` -> `ExecutionClientConf`](https://github.com/status-im/nimbus-eth1/pull/3780) - 2025-10-21
 * [Issue] [Remove nested `waitFor` call](https://github.com/status-im/nimbus-eth1/issues/3779) - 2025-10-21
 * [Issue] [Remove `blk` field from BlockRef](https://github.com/status-im/nimbus-eth1/issues/3778) - 2025-10-21
 * [Issue] [Update release, kurtosis etc to use `nimbus`](https://github.com/status-im/nimbus-eth1/issues/3793) - 2025-10-24
 
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-11-25
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [bump: websock](https://github.com/status-im/nimbus-eth1/pull/3829) - 2025-11-12
+* [Pull Request] [json_rpc: bump](https://github.com/status-im/nimbus-eth1/pull/3845) - 2025-11-25
+* [Pull Request] [json_rpc: bidirectional connections support](https://github.com/status-im/nimbus-eth1/pull/3856) - 2025-12-02
+* [Pull Request] [eth2: bump to v25.12.0+](https://github.com/status-im/nimbus-eth1/pull/3886) - 2025-12-30
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2025-10-29
+* [Pull Request] [Unify block proposer verification](https://github.com/status-im/nimbus-eth2/pull/7675) - 2025-10-29
 
-* [Pull Request] []() - 2025-11-05
-* [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [Block command-line supplied invalid blocks earlier](https://github.com/status-im/nimbus-eth2/pull/7714) - 2025-11-05
+* [Pull Request] [libbacktrace: bump](https://github.com/status-im/nimbus-eth2/pull/7791) - 2025-12-10
+* [Pull Request] [libbacktrace: bump](https://github.com/status-im/nimbus-eth2/pull/7791) - 2025-12-12
+* [Pull Request] [Only check isomorphism of types in debug compiles](https://github.com/status-im/nimbus-eth2/pull/7801) - 2025-12-15
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Issue] [Testnet genesis state descriptions out of date](https://github.com/ethereum/consensus-specs/issues/4720) - 2025-11-02
 ## Q3 2025

--- a/members/artiomtr.md
+++ b/members/artiomtr.md
@@ -12,44 +12,44 @@ Team: [Grandine](https://github.com/grandinetech/grandine), [rust-kzg](https://g
 
 
 [grandinetech/grandine](https://github.com/grandinetech/grandine)
-* [Pull Request] []() - 2026-01-02
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [Ignore RUSTSEC-2025-0137](https://github.com/grandinetech/grandine/pull/549) - 2026-01-02
+* [Pull Request] [Update rust toolchain to 1.92.0](https://github.com/grandinetech/grandine/pull/557) - 2026-01-05
+* [Pull Request] [Short tags for nethermind-grandine docker images](https://github.com/grandinetech/grandine/pull/556) - 2026-01-06
 
-* [Pull Request] []() - 2026-01-14
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-08
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [Update C# dependencies and bump .NET version to 10](https://github.com/grandinetech/grandine/pull/562) - 2026-01-14
+* [Pull Request] [Update risc0 prove code to use boundless network](https://github.com/grandinetech/grandine/pull/578) - 2026-01-28
+* [Pull Request] [Update rust toolchain to 1.92.0](https://github.com/grandinetech/grandine/pull/557) - 2026-02-04
+* [Pull Request] [Moved column (re)construction to dedicated executor](https://github.com/grandinetech/grandine/pull/596) - 2026-02-08
+* [Pull Request] [Disable nethermind build & publish for stable releases](https://github.com/grandinetech/grandine/pull/604) - 2026-02-23
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-12
+* [Pull Request] [Override default CLI option alias](https://github.com/NethermindEth/nethermind/pull/10148) - 2026-01-12
 
 [grandinetech/rust-kzg](https://github.com/grandinetech/rust-kzg)
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [Bump c kzg 4844 commit hash](https://github.com/grandinetech/rust-kzg/pull/325) - 2026-02-26
+* [Pull Request] [Bump c kzg 4844 commit hash](https://github.com/grandinetech/rust-kzg/pull/325) - 2026-02-27
+* [Pull Request] [Optimize batch addition](https://github.com/grandinetech/rust-kzg/pull/326) - 2026-03-05
 ## Q4 2025
 
 
 [grandinetech/rust-kzg](https://github.com/grandinetech/rust-kzg)
 * [Pull Request] [Fix handling of infinity points in bgmw algorithm](https://github.com/grandinetech/rust-kzg/pull/309) - 2025-10-08
 
-* [Pull Request] []() - 2025-10-29
-* [Pull Request] []() - 2025-11-06
-* [Pull Request] []() - 2025-11-07
+* [Pull Request] [Update to latest c-kzg-4844 commit hash](https://github.com/grandinetech/rust-kzg/pull/313) - 2025-10-29
+* [Pull Request] [Implement MSM fuzzing](https://github.com/grandinetech/rust-kzg/pull/314) - 2025-11-06
+* [Pull Request] [Added system setup documentation for ECC libraries](https://github.com/grandinetech/rust-kzg/pull/315) - 2025-11-07
 * [Issue] [Use our MSM for zkcrypto and arkworks3 backends](https://github.com/grandinetech/rust-kzg/issues/318) - 2025-11-10
-* [Pull Request] []() - 2025-11-21
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-31
+* [Pull Request] [Implement save/load precomputation tables to disk](https://github.com/grandinetech/rust-kzg/pull/320) - 2025-11-21
+* [Pull Request] [Removed mcl-windows from release build](https://github.com/grandinetech/rust-kzg/pull/321) - 2025-11-27
+* [Pull Request] [Removed mcl-windows from release build](https://github.com/grandinetech/rust-kzg/pull/321) - 2025-12-12
+* [Pull Request] [Bumped c-kzg-4844 commit hash](https://github.com/grandinetech/rust-kzg/pull/323) - 2025-12-16
+* [Pull Request] [Create makefile](https://github.com/grandinetech/rust-kzg/pull/324) - 2025-12-31
 [grandinetech/grandine](https://github.com/grandinetech/grandine)
-* [Pull Request] []() - 2025-10-16
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [Update rust-kzg to latest version](https://github.com/grandinetech/grandine/pull/428) - 2025-10-16
+* [Pull Request] [Update rust-kzg](https://github.com/grandinetech/grandine/pull/452) - 2025-10-30
+* [Pull Request] [Implement grandine-nethermind integration](https://github.com/grandinetech/grandine/pull/476) - 2025-11-12
+* [Pull Request] [Fixed grandine docker image build process](https://github.com/grandinetech/grandine/pull/527) - 2025-12-09
+* [Pull Request] [Exclude ziren guest code when compiling grandine](https://github.com/grandinetech/grandine/pull/530) - 2025-12-10
+* [Pull Request] [Provide GITHUB_TOKEN during risc0 installation](https://github.com/grandinetech/grandine/pull/536) - 2025-12-15
 ## Q3 2025
 
 

--- a/members/asdacap.md
+++ b/members/asdacap.md
@@ -13,12 +13,12 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
 * [Issue] [Warn when dirty prune cache is too low](https://github.com/NethermindEth/nethermind/issues/10142) - 2026-01-08
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-22
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-01
+* [Pull Request] [Fix higher than expected pruning cache memory during forward sync.](https://github.com/NethermindEth/nethermind/pull/10336) - 2026-01-27
+* [Pull Request] [fix: correct Bytes.BytesComparer length comparison ordering](https://github.com/NethermindEth/nethermind/pull/10353) - 2026-01-29
+* [Pull Request] [Remove unused IsPersisted method from TrieStore](https://github.com/NethermindEth/nethermind/pull/10570) - 2026-02-18
+* [Pull Request] [Fix random invalid block](https://github.com/NethermindEth/nethermind/pull/10613) - 2026-02-22
+* [Pull Request] [Perf/simple flat](https://github.com/NethermindEth/nethermind/pull/9854) - 2026-02-25
+* [Pull Request] [Remove global mutable state from Rlp decoder registry](https://github.com/NethermindEth/nethermind/pull/10686) - 2026-03-01
 ## Q4 2025
 
 
@@ -43,14 +43,14 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Commit] [XDC : Snapshot Manager (#9318)](https://github.com/NethermindEth/nethermind/commit/fc220422be392edd27b545026a1081f4f9ed9e18) - 2025-10-13
 * [Commit] [Fix logs in eth_simulate (#9437)](https://github.com/NethermindEth/nethermind/commit/a1e10b65141c1fd689129637ad906c1e655377e7) - 2025-10-13
 * [Commit] [Fix concurrent tree read (#9447)](https://github.com/NethermindEth/nethermind/commit/c5cfd08169511f1043dab34fea375d70cfa43210) - 2025-10-13
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-18
-* [Pull Request] []() - 2025-11-25
-* [Pull Request] []() - 2025-12-01
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-14
-* [Pull Request] []() - 2025-12-27
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [Fix it maybe](https://github.com/NethermindEth/nethermind/pull/9456) - 2025-10-14
+* [Pull Request] [Test/Do not mutate commit buffer](https://github.com/NethermindEth/nethermind/pull/9498) - 2025-10-18
+* [Pull Request] [fix master build](https://github.com/NethermindEth/nethermind/pull/9769) - 2025-11-25
+* [Pull Request] [Perf/simple flat](https://github.com/NethermindEth/nethermind/pull/9854) - 2025-12-01
+* [Pull Request] [Test/ disable mark persisted](https://github.com/NethermindEth/nethermind/pull/9919) - 2025-12-11
+* [Pull Request] [Fix hanging scenario if persisted node not able to be pruned](https://github.com/NethermindEth/nethermind/pull/9931) - 2025-12-14
+* [Pull Request] [Fix/isStorageEmpty check does not get reflected until after commit.](https://github.com/NethermindEth/nethermind/pull/10039) - 2025-12-27
+* [Pull Request] [Perf/TryGetDirtyNode](https://github.com/NethermindEth/nethermind/pull/10067) - 2025-12-30
 ## Q3 2025
 
 

--- a/members/asdacap.md
+++ b/members/asdacap.md
@@ -19,6 +19,9 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Pull Request] [Fix random invalid block](https://github.com/NethermindEth/nethermind/pull/10613) - 2026-02-22
 * [Pull Request] [Perf/simple flat](https://github.com/NethermindEth/nethermind/pull/9854) - 2026-02-25
 * [Pull Request] [Remove global mutable state from Rlp decoder registry](https://github.com/NethermindEth/nethermind/pull/10686) - 2026-03-01
+
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Review] [Review on: Flat/snap sync refactor](https://github.com/NethermindEth/nethermind/pull/10772#pullrequestreview-3925754440) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/askalexsharov.md
+++ b/members/askalexsharov.md
@@ -36,6 +36,19 @@ Team: Erigon
 * [Pull Request] [recsplit: keyPos reset on retry](https://github.com/erigontech/erigon/pull/19773) - 2026-03-10
 * [Pull Request] [merge `release/3.4` to `main`](https://github.com/erigontech/erigon/pull/19772) - 2026-03-10
 * [Issue] [etl: `memoryDataProvider.Next` to return zero-copy](https://github.com/erigontech/erigon/issues/19778) - 2026-03-10
+* [Review] [Review on: claude: add CI test skills (unit, all, race, hive, rpc, ci-orchestrator)](https://github.com/erigontech/erigon/pull/19784#pullrequestreview-3926266438) - 2026-03-11
+* [Review] [Review on: snapcfg: load preverified hashes for single chain only](https://github.com/erigontech/erigon/pull/19785#pullrequestreview-3926261390) - 2026-03-11
+* [Review] [Review on: execution/tests: fix state test DB contention](https://github.com/erigontech/erigon/pull/19767#pullrequestreview-3919308978) - 2026-03-10
+* [Review] [Review on: docs: remove MCP documentation from main (3.3.x)](https://github.com/erigontech/erigon/pull/19756#pullrequestreview-3919836710) - 2026-03-10
+* [Review] [Review on: Cherry-pick #19698: UnitTest for reset page counter on collision in buildVI](https://github.com/erigontech/erigon/pull/19754#pullrequestreview-3921135043) - 2026-03-10
+* [Review] [Review on: txpool: replace custom RLP parsing with standard transaction types](https://github.com/erigontech/erigon/pull/19757#pullrequestreview-3920173700) - 2026-03-10
+* [Review] [Review on: execution/stagedsync: enable deferred commitment updates for parallel fork validation](https://github.com/erigontech/erigon/pull/19749#pullrequestreview-3919826017) - 2026-03-10
+* [Review] [Review on: [SharovBot] ci: increase test timeout to 30m on windows-2025 to fix eest_blockchain marginal failure](https://github.com/erigontech/erigon/pull/19771#pullrequestreview-3919861523) - 2026-03-10
+* [Review] [Review on: ci, make: add test-bench to verify all benchmarks compile and run](https://github.com/erigontech/erigon/pull/19745#pullrequestreview-3919642929) - 2026-03-10
+* [Review] [Review on: [r3.4] [cherry-pick] Migrate bloatnet to perf-devnet-3 and fix genesis hash collisions (#19741)](https://github.com/erigontech/erigon/pull/19753#pullrequestreview-3919833242) - 2026-03-10
+
+[erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
+* [Review] [Review on: added maxUsedGas field in eth_simulateV1](https://github.com/erigontech/rpc-tests/pull/528#pullrequestreview-3919728243) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/askalexsharov.md
+++ b/members/askalexsharov.md
@@ -31,6 +31,7 @@ Team: Erigon
 * [Issue] [Sentinel: race on find Peers and NewAddrBook](https://github.com/erigontech/erigon/issues/19603) - 2026-03-04
 * [Pull Request] []() - 2026-03-06
 * [Pull Request] []() - 2026-03-08
+* [Issue] [etl: `memoryDataProvider.Next` to return zero-copy](https://github.com/erigontech/erigon/issues/19778) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/askalexsharov.md
+++ b/members/askalexsharov.md
@@ -18,19 +18,24 @@ Team: Erigon
 * [Issue] [StateCache: enable it in all tooling](https://github.com/erigontech/erigon/issues/18949) - 2026-02-04
 * [Issue] [StateCache: enable it in all tests](https://github.com/erigontech/erigon/issues/18948) - 2026-02-04
 * [Issue] [Pipe-fix for win](https://github.com/erigontech/erigon/issues/18950) - 2026-02-04
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [move "batch size estimation" biz-logic from SD to Exec](https://github.com/erigontech/erigon/pull/19011) - 2026-02-06
 * [Issue] [integrity check: false-positive about headers files](https://github.com/erigontech/erigon/issues/19181) - 2026-02-14
 * [Issue] [`gap in visible files`: during exec from 0](https://github.com/erigontech/erigon/issues/19178) - 2026-02-14
-* [Pull Request] []() - 2026-02-16
+* [Pull Request] [p2p tests: reduce amount of quickcheck iterations to speeduptests](https://github.com/erigontech/erigon/pull/19214) - 2026-02-16
 * [Issue] [eth_getLogs to not check state history progress if node synced with `--persist.receipt`](https://github.com/erigontech/erigon/issues/19215) - 2026-02-16
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [vvv](https://github.com/erigontech/erigon/pull/19283) - 2026-02-18
 * [Issue] [Merge: speed task list](https://github.com/erigontech/erigon/issues/19430) - 2026-02-23
 * [Issue] [TestShutterBlockBuilding: flaky](https://github.com/erigontech/erigon/issues/19444) - 2026-02-24
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [StateFerify: use `etl`](https://github.com/erigontech/erigon/pull/19504) - 2026-02-26
 * [Issue] [Integrity: reproducible sampling](https://github.com/erigontech/erigon/issues/19617) - 2026-03-04
 * [Issue] [Sentinel: race on find Peers and NewAddrBook](https://github.com/erigontech/erigon/issues/19603) - 2026-03-04
-* [Pull Request] []() - 2026-03-06
-* [Pull Request] []() - 2026-03-08
+* [Pull Request] [UnitTest: for reset page counter on collision in buildVI](https://github.com/erigontech/erigon/pull/19698) - 2026-03-06
+* [Pull Request] [up `x` deps](https://github.com/erigontech/erigon/pull/19726) - 2026-03-08
+* [Pull Request] [mark `commitment history` feature as non-experimental](https://github.com/erigontech/erigon/pull/19774) - 2026-03-10
+* [Pull Request] [[wip] etl: zero-copy memDataProvider](https://github.com/erigontech/erigon/pull/19780) - 2026-03-10
+* [Pull Request] [recsplit: keyPos reset on retry](https://github.com/erigontech/erigon/pull/19773) - 2026-03-10
+* [Pull Request] [merge `release/3.4` to `main`](https://github.com/erigontech/erigon/pull/19772) - 2026-03-10
+* [Issue] [etl: `memoryDataProvider.Next` to return zero-copy](https://github.com/erigontech/erigon/issues/19778) - 2026-03-10
 ## Q4 2025
 
 
@@ -111,15 +116,15 @@ Team: Erigon
 * [Issue] [`make lint` can't find linter's binary](https://github.com/erigontech/erigon/issues/17432) - 2025-10-13
 * [Pull Request] [nodedb: set `dbSyncPeriod=5mb`](https://github.com/erigontech/erigon/pull/17431) - 2025-10-13
 * [Commit] [mdbx: v0.13.8 (#17284)](https://github.com/erigontech/erigon/commit/34fcd734fdfc52adea725578c6adde9ed7a2436a) - 2025-10-13
-* [Pull Request] []() - 2025-10-20
-* [Pull Request] []() - 2025-10-25
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [prune: avoid using same metric by furious prune](https://github.com/erigontech/erigon/pull/17547) - 2025-10-20
+* [Pull Request] [mdbx_stat: add Reclaimable space in gb to command](https://github.com/erigontech/erigon/pull/17656) - 2025-10-25
+* [Pull Request] [extract closeWhatNotInList to dirty_files.go](https://github.com/erigontech/erigon/pull/17665) - 2025-10-27
 * [Issue] [grafana: prune metrics - switch from histogram to summary](https://github.com/erigontech/erigon/issues/17725) - 2025-10-31
 * [Issue] [grafana: `prune_stage_duration_secs` metric - don't see data](https://github.com/erigontech/erigon/issues/17724) - 2025-10-31
-* [Pull Request] []() - 2025-11-21
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-22
+* [Pull Request] [[3.3] remove experimental tag for historical commitments trie](https://github.com/erigontech/erigon/pull/18011) - 2025-11-21
+* [Pull Request] [systems settings advise had invalid format ](https://github.com/erigontech/erigon/pull/18148) - 2025-12-03
+* [Pull Request] [merge `release/3.3` to `main`](https://github.com/erigontech/erigon/pull/18251) - 2025-12-11
+* [Pull Request] [[wip] mdbx: default gc_aug_limit](https://github.com/erigontech/erigon/pull/18412) - 2025-12-22
 ## Q3 2025
 
 

--- a/members/awskii.md
+++ b/members/awskii.md
@@ -20,11 +20,11 @@ Team: Erigon
 * [Issue] [Snapshot checkers](https://github.com/erigontech/erigon/issues/17325) - 2025-10-02
 * [Commit] [arb: decrease log level for wasm activation (#17352)](https://github.com/erigontech/erigon/commit/ba2bc44f25f1e1133d5c900c44e528473a9e3532) - 2025-10-06
 * [Pull Request] [arb: decrease log level for wasm activation](https://github.com/erigontech/erigon/pull/17352) - 2025-10-06
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-17
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-27
+* [Pull Request] [let arbitrum nitro work further (unless fixed in OCL/nitro)](https://github.com/erigontech/erigon/pull/17458) - 2025-10-14
+* [Pull Request] [Commitment: renamings and movements](https://github.com/erigontech/erigon/pull/17530) - 2025-10-17
+* [Pull Request] [Arb/block main](https://github.com/erigontech/erigon/pull/17768) - 2025-11-04
+* [Pull Request] [[DNM] arbos50+main into clean arbitrum](https://github.com/erigontech/erigon/pull/18207) - 2025-12-08
+* [Pull Request] [Update arb-sepolia snapshots to 228M](https://github.com/erigontech/erigon/pull/18481) - 2025-12-27
 ## Q3 2025
 
 

--- a/members/awskii.md
+++ b/members/awskii.md
@@ -13,6 +13,9 @@ Team: Erigon
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
 * [Issue] [`MDBX_EKEYMISMATCH` on chain tip block insertion](https://github.com/erigontech/erigon/issues/19082) - 2026-02-10
+
+[protocolguild/documentation](https://github.com/protocolguild/documentation)
+* [Review] [Review on: Update Erigon contributions with Zilkworm link](https://github.com/protocolguild/documentation/pull/478#pullrequestreview-3925895357) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/b-wagn.md
+++ b/members/b-wagn.md
@@ -12,7 +12,7 @@ Team: Cryptography (EF)
 
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [Add Thomas Coratger](https://github.com/protocolguild/documentation/pull/444) - 2025-10-15
 ## Q3 2025
 
 [ethereum/pm](https://github.com/ethereum/pm)

--- a/members/barnabasbusa.md
+++ b/members/barnabasbusa.md
@@ -15,14 +15,14 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Issue] [Prysm vc `500: UNHANDLED_ERROR: UnableToReadSlot`](https://github.com/sigp/lighthouse/issues/8624) - 2026-01-05
 
 [ethpandaops/dora](https://github.com/ethpandaops/dora)
-* [Pull Request] []() - 2026-01-09
+* [Pull Request] [Update Go base image version to 1.25.1](https://github.com/ethpandaops/dora/pull/552) - 2026-01-09
 
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [feat: add block filter view](https://github.com/ethpandaops/dora/pull/568) - 2026-02-09
+* [Pull Request] [feat(epochs): display proposal participation in epochs page](https://github.com/ethpandaops/dora/pull/583) - 2026-02-16
+* [Pull Request] [fix: add missing SQL placeholder for orphaned blocks insert](https://github.com/ethpandaops/dora/pull/600) - 2026-03-06
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-16
+* [Pull Request] [fix: add triple-beam dependency to package.json](https://github.com/ChainSafe/lodestar/pull/8736) - 2026-01-12
+* [Pull Request] [feat: implement eip 7843](https://github.com/ChainSafe/lodestar/pull/8747) - 2026-01-16
 
 [consensys/teku](https://github.com/consensys/teku)
 * [Issue] [FR: add `--force-clear-db` to wipe the existing db at startup](https://github.com/Consensys/teku/issues/10313) - 2026-02-02
@@ -37,14 +37,14 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Issue] [All Core Devs - Testing (ACDT) #70, February 16, 2026](https://github.com/ethereum/pm/issues/1920) - 2026-02-10
 
 [ethpandaops/template-devnets](https://github.com/ethpandaops/template-devnets)
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [Add containerd-snapshotter feature option](https://github.com/ethpandaops/template-devnets/pull/150) - 2026-02-10
+* [Pull Request] [feat: merge do and hc](https://github.com/ethpandaops/template-devnets/pull/152) - 2026-02-11
+* [Pull Request] [feat: merge do and hc](https://github.com/ethpandaops/template-devnets/pull/152) - 2026-02-24
 
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [fix: small fixes and dep update](https://github.com/ethpandaops/template-devnets/pull/154) - 2026-03-03
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [Update EIP-7870: realistic minimum numbers](https://github.com/ethereum/EIPs/pull/11356) - 2026-02-26
+* [Pull Request] [Update EIP-7870: realistic minimum numbers](https://github.com/ethereum/EIPs/pull/11356) - 2026-03-02
 ## Q4 2025
 
 
@@ -53,27 +53,27 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Commit] [fix: add supported columns as an array instead of bool](https://github.com/ethpandaops/dora/commit/f816bc222e9f8ea5532b50220530acdf713cfa2c) - 2025-10-02
 
 * [Issue] [do validator look ahead on n+1 epoch](https://github.com/ethpandaops/dora/issues/524) - 2025-12-01
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [feat: add el status message viewer](https://github.com/ethpandaops/dora/pull/536) - 2025-12-11
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
 * [Issue] [Default to EL<version>CL<version> in graffiti](https://github.com/status-im/nimbus-eth2/issues/7580) - 2025-10-08
 
-* [Pull Request] []() - 2025-12-05
+* [Pull Request] [fix: bpo spec initialization for genesis](https://github.com/status-im/nimbus-eth2/pull/7780) - 2025-12-05
 * [Issue] [Broken config if BPO is scheduled to genesis.](https://github.com/status-im/nimbus-eth2/issues/7778) - 2025-12-05
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Update 7949: specify each field explicitly](https://github.com/ethereum/EIPs/pull/10503) - 2025-10-09
 
 [ethpandaops/template-devnets](https://github.com/ethpandaops/template-devnets)
-* [Pull Request] []() - 2025-10-21
+* [Pull Request] [Update geth init](https://github.com/ethpandaops/template-devnets/pull/134) - 2025-10-21
 
 [ethereum/pm](https://github.com/ethereum/pm)
-* [Pull Request] []() - 2025-10-23
+* [Pull Request] [Clarify mainnet upgrade date requirement](https://github.com/ethereum/pm/pull/1780) - 2025-10-23
 * [Issue] [All Core Devs - Testing (ACDT) #60, November 3, 2025](https://github.com/ethereum/pm/issues/1786) - 2025-10-28
 * [Issue] [All Core Devs - Testing (ACDT) #62, December 1, 2025](https://github.com/ethereum/pm/issues/1820) - 2025-11-27
 * [Issue] [All Core Devs - Testing (ACDT) #64, December 15, 2025](https://github.com/ethereum/pm/issues/1842) - 2025-12-12
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
 * [Issue] [Missing values in `/eth/v1/config/spec`](https://github.com/sigp/lighthouse/issues/8571) - 2025-12-12
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [Adjust effective_epoch calculation for genesis case](https://github.com/sigp/lighthouse/pull/8584) - 2025-12-15
 * [Issue] [Columns pruned within boundary finalization bug](https://github.com/sigp/lighthouse/issues/8583) - 2025-12-15
 ## Q3 2025
 

--- a/members/benaadams.md
+++ b/members/benaadams.md
@@ -33,6 +33,18 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Pull Request] [Eliminate per-instance ValueFactory delegate allocations in PrewarmerScopeProvider](https://github.com/NethermindEth/nethermind/pull/10754) - 2026-03-10
 * [Commit] [Add multi-platform CI test matrix (arm64, Windows, macOS) (#10761)](https://github.com/NethermindEth/nethermind/commit/a33f0afc212e3892be2e551c997a588e6ab358a3) - 2026-03-10
 * [Commit] [Eliminate per-instance ValueFactory delegate allocations in PrewarmerScopeProvider (#10754)](https://github.com/NethermindEth/nethermind/commit/3133ddbd2a7f000c2ff07105752ac678a7e9fa41) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3924805317) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3924806386) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3924829759) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3925024337) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3925026201) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3925028192) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3925029033) - 2026-03-10
+* [Review] [Review on: perf: CountZeros SIMD — fix boundary fallback and optimize ARM path](https://github.com/NethermindEth/nethermind/pull/10757#pullrequestreview-3925392011) - 2026-03-10
+* [Review] [Review on: Fix event handler leaks, reduce allocations, and refactor Network layer](https://github.com/NethermindEth/nethermind/pull/10753#pullrequestreview-3925374244) - 2026-03-10
+* [Review] [Review on: docs: Clarify guideline about infra](https://github.com/NethermindEth/nethermind/pull/10767#pullrequestreview-3923317639) - 2026-03-10
+* [Review] [Review on: Expand retry cache](https://github.com/NethermindEth/nethermind/pull/10739#pullrequestreview-3923369324) - 2026-03-10
+* [Review] [Review on: fix(ui): assign slice result to txsToAdd array](https://github.com/NethermindEth/nethermind/pull/10724#pullrequestreview-3923360517) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/benaadams.md
+++ b/members/benaadams.md
@@ -12,21 +12,27 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [Optimize EVM](https://github.com/NethermindEth/nethermind/pull/10120) - 2026-01-06
+* [Pull Request] [Optimize storage key handling](https://github.com/NethermindEth/nethermind/pull/10241) - 2026-01-14
 
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [EIP-7778: Block Gas Accounting without Refunds](https://github.com/NethermindEth/nethermind/pull/10292) - 2026-01-26
+* [Pull Request] [Skip cache for identity precompile](https://github.com/NethermindEth/nethermind/pull/10366) - 2026-02-01
+* [Pull Request] [Optimize Json hex parsing](https://github.com/NethermindEth/nethermind/pull/10389) - 2026-02-02
+* [Pull Request] [Add JitAsm tool to be able to analyse the Jit output](https://github.com/NethermindEth/nethermind/pull/10432) - 2026-02-06
+* [Pull Request] [Initialize P2P subprotocols after ProtocolInitialized event](https://github.com/NethermindEth/nethermind/pull/10489) - 2026-02-11
+* [Pull Request] [fix(test): fix race condition in BlockchainProcessorTests (flaky test)](https://github.com/NethermindEth/nethermind/pull/10513) - 2026-02-13
+* [Pull Request] [formatting](https://github.com/NethermindEth/nethermind/pull/10714) - 2026-03-03
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-20
+* [Pull Request] [Update EIP-7954: Move to Draft](https://github.com/ethereum/EIPs/pull/11116) - 2026-01-20
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [EIP-8037: Add tests for three missing gas-validation and code-deposit edge cases](https://github.com/ethereum/execution-specs/issues/2426) - 2026-03-06
+
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Pull Request] [Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761) - 2026-03-10
+* [Pull Request] [Eliminate per-instance ValueFactory delegate allocations in PrewarmerScopeProvider](https://github.com/NethermindEth/nethermind/pull/10754) - 2026-03-10
+* [Commit] [Add multi-platform CI test matrix (arm64, Windows, macOS) (#10761)](https://github.com/NethermindEth/nethermind/commit/a33f0afc212e3892be2e551c997a588e6ab358a3) - 2026-03-10
+* [Commit] [Eliminate per-instance ValueFactory delegate allocations in PrewarmerScopeProvider (#10754)](https://github.com/NethermindEth/nethermind/commit/3133ddbd2a7f000c2ff07105752ac678a7e9fa41) - 2026-03-10
 ## Q4 2025
 
 
@@ -61,15 +67,15 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Commit] [Set Ethereum mainnet default gaslimit to 60M](https://github.com/NethermindEth/nethermind/commit/394a1d477a5b1874b371fb36d83841144c3edaa6) - 2025-10-13
 * [Commit] [Add OutputCache to metrics endpoint (#9139)](https://github.com/NethermindEth/nethermind/commit/026fa2bed0f0ec331944263daa15e8322466d440) - 2025-10-13
 
-* [Pull Request] []() - 2025-10-29
-* [Pull Request] []() - 2025-12-28
-* [Pull Request] []() - 2025-12-29
+* [Pull Request] [Reduce peer logging](https://github.com/NethermindEth/nethermind/pull/9591) - 2025-10-29
+* [Pull Request] [Check for 0 in MOD opcode](https://github.com/NethermindEth/nethermind/pull/10061) - 2025-12-28
+* [Pull Request] [Check for 0 in MOD opcode](https://github.com/NethermindEth/nethermind/pull/10061) - 2025-12-29
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-10-24
-* [Pull Request] []() - 2025-10-25
-* [Pull Request] []() - 2025-10-26
-* [Pull Request] []() - 2025-11-03
+* [Pull Request] [Update EIP-2780: Bullet points](https://github.com/ethereum/EIPs/pull/10596) - 2025-10-23
+* [Pull Request] [Update EIP-8007: Propose EIP-8057](https://github.com/ethereum/EIPs/pull/10603) - 2025-10-24
+* [Pull Request] [Update EIP-8057: Formatting](https://github.com/ethereum/EIPs/pull/10609) - 2025-10-25
+* [Pull Request] [Update EIP-2780: Add formula](https://github.com/ethereum/EIPs/pull/10618) - 2025-10-26
+* [Pull Request] [Update EIP-8057: Remove spam](https://github.com/ethereum/EIPs/pull/10700) - 2025-11-03
 ## Q3 2025
 
 

--- a/members/bhartnett.md
+++ b/members/bhartnett.md
@@ -12,12 +12,13 @@ Team: [status-im/nimbus-eth1 Portal](https://github.com/status-im/nimbus-eth1/pu
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2026-01-20
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Implement eth_getBlockAccessListByBlockHash and eth_getBlockAccessListByBlockNumber](https://github.com/status-im/nimbus-eth1/pull/3918) - 2026-01-20
+* [Pull Request] [EIP-7928: Implement engine_getPayloadBodiesByHashV2 and engine_getPayloadBodiesByRangeV2](https://github.com/status-im/nimbus-eth1/pull/3967) - 2026-02-05
+* [Pull Request] [Fix devp2p sync for non-finalized Amsterdam blocks](https://github.com/status-im/nimbus-eth1/pull/3971) - 2026-02-09
+* [Pull Request] [Implement BAL size cap check and other validation improvements](https://github.com/status-im/nimbus-eth1/pull/3995) - 2026-02-19
+* [Pull Request] [Try updating to orc](https://github.com/status-im/nimbus-eth1/pull/4016) - 2026-02-25
+* [Pull Request] [eth/71 - Serve block access lists to peers](https://github.com/status-im/nimbus-eth1/pull/4035) - 2026-03-06
+* [Pull Request] [Vertex as object instead of ref object](https://github.com/status-im/nimbus-eth1/pull/4039) - 2026-03-10
 ## Q4 2025
 
 
@@ -40,20 +41,20 @@ Team: [status-im/nimbus-eth1 Portal](https://github.com/status-im/nimbus-eth1/pu
 * [Commit] [Remove unused admCol column family.](https://github.com/status-im/nimbus-eth1/commit/633f1a0059044d4cc52e2f5f3152b8aab36874d3) - 2025-10-09
 * [Pull Request] [Remove legacy SavedStateV0 from database](https://github.com/status-im/nimbus-eth1/pull/3756) - 2025-10-09
 * [Commit] [Add parameter to skip loading forked chain state on startup (#3754)](https://github.com/status-im/nimbus-eth1/commit/9013b27e35c65156ef2f9c40dd203a3bde869ad2) - 2025-10-09
-* [Pull Request] []() - 2025-10-14
+* [Pull Request] [Support column families in kvt txFrame API and use for contract code](https://github.com/status-im/nimbus-eth1/pull/3765) - 2025-10-14
 * [Issue] [Parallel transaction execution using Block-Level Access Lists](https://github.com/status-im/nimbus-eth1/issues/3771) - 2025-10-16
 * [Issue] [AssertionDefect in ForkedChain - candidate BlockRef is nil in updateFinalized ](https://github.com/status-im/nimbus-eth1/issues/3777) - 2025-10-21
-* [Pull Request] []() - 2025-10-29
-* [Pull Request] []() - 2025-11-03
+* [Pull Request] [EIP-7928: Engine API changes introduced in Amsterdam](https://github.com/status-im/nimbus-eth1/pull/3801) - 2025-10-29
+* [Pull Request] [Make the max snapshots database parameter configurable](https://github.com/status-im/nimbus-eth1/pull/3808) - 2025-11-03
 
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-15
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [Run all EEST engine tests, not just ones in static folder](https://github.com/status-im/nimbus-eth1/pull/3846) - 2025-11-27
+* [Pull Request] [EIP-7928: Block level access lists (#3836)](https://github.com/status-im/nimbus-eth1/pull/3850) - 2025-11-28
+* [Pull Request] [EIP-7928: Implement debug_getBadBlocks RPC endpoint](https://github.com/status-im/nimbus-eth1/pull/3865) - 2025-12-05
+* [Pull Request] [Apply static gas checks for EIP-2929 self destruct](https://github.com/status-im/nimbus-eth1/pull/3878) - 2025-12-15
+* [Pull Request] [Remove unused imports and disable persist performance metrics on bare metal](https://github.com/status-im/nimbus-eth1/pull/3880) - 2025-12-16
+* [Pull Request] [Stateless makefile targets](https://github.com/status-im/nimbus-eth1/pull/3887) - 2025-12-23
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-11-21
+* [Pull Request] [Update EIP-7928: Update StorageKey and StorageValue type definitions](https://github.com/ethereum/EIPs/pull/10817) - 2025-11-21
 ## Q3 2025
 
 

--- a/members/bhartnett.md
+++ b/members/bhartnett.md
@@ -18,6 +18,7 @@ Team: [status-im/nimbus-eth1 Portal](https://github.com/status-im/nimbus-eth1/pu
 * [Pull Request] []() - 2026-02-19
 * [Pull Request] []() - 2026-02-25
 * [Pull Request] []() - 2026-03-06
+* [Pull Request] []() - 2026-03-10
 ## Q4 2025
 
 

--- a/members/bshastry.md
+++ b/members/bshastry.md
@@ -12,10 +12,10 @@ Team: [ethereum/protocol-security](https://github.com/ethereum/protocol-security
 
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2026-01-13
+* [Pull Request] [feat(test-tests) add testcase for calldata/codecopy OOG](https://github.com/ethereum/execution-specs/pull/2012) - 2026-01-13
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [fix(test-runner): Use maxPriorityFeePerGas for EIP-1559 state test parsing](https://github.com/NethermindEth/nethermind/pull/10205) - 2026-01-14
 
 [ethereum/evmone](https://github.com/ethereum/evmone)
 * [Issue] [EIP-7702: Consensus bugs in authorization processing (meta)](https://github.com/ipsilon/evmone/issues/1449) - 2026-02-10
@@ -31,23 +31,23 @@ Team: [ethereum/protocol-security](https://github.com/ethereum/protocol-security
 * [Pull Request] [Feature/blocktest tracing](https://github.com/NethermindEth/nethermind/pull/9427) - 2025-10-08
 * [Pull Request] [Fix: Blocktest validation bypass for NoProof seal engine](https://github.com/NethermindEth/nethermind/pull/9439) - 2025-10-10
 
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [fix: only touch coinbase after successful transaction in state tests](https://github.com/NethermindEth/nethermind/pull/9865) - 2025-12-02
 * [Pull Request] []() - 2025-12-16
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2025-10-14
+* [Pull Request] [Add transaction tracing support to block test command](https://github.com/besu-eth/besu/pull/9310) - 2025-10-14
 
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-06
+* [Pull Request] [fix: only touch coinbase after valid transaction in state tests](https://github.com/besu-eth/besu/pull/9524) - 2025-12-03
+* [Pull Request] [fix(evmtool): use excessBlobGas from test environment in state-test](https://github.com/besu-eth/besu/pull/9545) - 2025-12-06
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [[tooling] Docker build fails: ethereum-execution-specs[test] extra not installable](https://github.com/ethereum/execution-specs/issues/1630) - 2025-10-17
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
 * [Issue] [State test runner ignores `blobVersionedHashes` when `txbytes` is absent](https://github.com/erigontech/erigon/issues/18079) - 2025-11-27
 
-* [Pull Request] []() - 2025-12-04
+* [Pull Request] [tests: fix statetest message construction to match other clients](https://github.com/erigontech/erigon/pull/18121) - 2025-12-04
 [bluealloy/revm](https://github.com/bluealloy/revm)
-* [Pull Request] []() - 2025-12-01
-* [Pull Request] []() - 2025-12-05
+* [Pull Request] [feat(statetest): spec-compliant expected exception handling](https://github.com/bluealloy/revm/pull/3198) - 2025-12-01
+* [Pull Request] [fix(statetest): use spec-aware blob base fee update fraction](https://github.com/bluealloy/revm/pull/3210) - 2025-12-05
 * [Pull Request] []() - 2025-12-08
 ## Q3 2025
 

--- a/members/canepat.md
+++ b/members/canepat.md
@@ -12,22 +12,22 @@ Team: [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=autho
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-10
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [rpc: fix block not found in eth_getBalance and others](https://github.com/erigontech/erigon/pull/18457) - 2026-01-10
+* [Pull Request] [rpc: EIP-7966 eth_sendRawTransactionSync](https://github.com/erigontech/erigon/pull/18672) - 2026-01-14
 * [Issue] [eth_call on Multicall3 contract different response full vs archive](https://github.com/erigontech/erigon/issues/18722) - 2026-01-20
 * [Issue] [debug_traceBlockByNumber: test_44 mismatch on latest block: 24298763](https://github.com/erigontech/erigon/issues/18783) - 2026-01-23
-* [Pull Request] []() - 2026-01-23
+* [Pull Request] [rpc: compute root from state history in eth_simulateV1](https://github.com/erigontech/erigon/pull/18782) - 2026-01-23
 
 * [Issue] [rpc: add block timestamp to eth_getTransactionByHash](https://github.com/erigontech/erigon/issues/18811) - 2026-01-26
 * [Issue] [rpc: add support for `debug_setHead`](https://github.com/erigontech/erigon/issues/18922) - 2026-02-02
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-07
+* [Pull Request] [qa-tests: fix summary in RPC Performance Tests Latest](https://github.com/erigontech/erigon/pull/18984) - 2026-02-05
+* [Pull Request] [[r33] rpc: env var for disabling receipt LRU caches](https://github.com/erigontech/erigon/pull/19027) - 2026-02-07
 * [Issue] [rpc: add support for testing_buildBlockV1](https://github.com/erigontech/erigon/issues/19054) - 2026-02-09
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [rpc: avoid header read in eth_feeHistory](https://github.com/erigontech/erigon/pull/19127) - 2026-02-11
 * [Issue] [eth: add eth_capabilities RPC method](https://github.com/erigontech/erigon/issues/19762) - 2026-03-09
 * [Issue] [hive: rpc-compat failing test](https://github.com/erigontech/erigon/issues/19758) - 2026-03-09
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
-* [Pull Request] []() - 2026-01-26
+* [Pull Request] [perf: fix system-under-test name in alive check](https://github.com/erigontech/rpc-tests/pull/513) - 2026-01-26
 * [Pull Request] []() - 2026-01-28
 ## Q4 2025
 
@@ -60,16 +60,16 @@ Team: [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=autho
 * [Pull Request] [tests: fix data race in HexPatriciaHashed parallel tests](https://github.com/erigontech/erigon/pull/17423) - 2025-10-11
 * [Issue] [Data race in hex_patricia_hashed_test.go tests](https://github.com/erigontech/erigon/issues/17422) - 2025-10-11
 * [Issue] [Flaky test TestMergedFileGet](https://github.com/erigontech/erigon/issues/17532) - 2025-10-18
-* [Pull Request] []() - 2025-11-03
+* [Pull Request] [tests: fix deadlock in TestWebsocketLargeCall - 2nd try](https://github.com/erigontech/erigon/pull/17762) - 2025-11-03
 * [Issue] [hive: fix remaining `rpc-compat` failing tests](https://github.com/erigontech/erigon/issues/17859) - 2025-11-11
 * [Issue] [User issues migrating from 3.0.15 to 3.2 in Docker on Windows](https://github.com/erigontech/erigon/issues/17855) - 2025-11-11
 * [Issue] [rpc: eth_estimateGas returns value greater than expected](https://github.com/erigontech/erigon/issues/17869) - 2025-11-12
-* [Pull Request] []() - 2025-11-19
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [[r3.3] rpcdaemon: insert CommitBlock only for API where specific test is present](https://github.com/erigontech/erigon/pull/17963) - 2025-11-19
+* [Pull Request] [qa-tests: enable eth_getProof test 24](https://github.com/erigontech/erigon/pull/18131) - 2025-12-02
 * [Issue] [QA: add Caplin+Erigon in external mode configuration](https://github.com/erigontech/erigon/issues/18163) - 2025-12-04
 * [Issue] [Erigon 3.3.0 stuck at block 23,935,693 after invalid block](https://github.com/erigontech/erigon/issues/18213) - 2025-12-08
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [rpc: fix invalid key error code in eth_getStorageAt](https://github.com/erigontech/erigon/pull/18228) - 2025-12-09
+* [Pull Request] [rpc: fix batch limit exceeded error as per JSONRPC spec](https://github.com/erigontech/erigon/pull/18260) - 2025-12-11
 * [Issue] [EL: add max blobs config parameter for block production](https://github.com/erigontech/erigon/issues/18318) - 2025-12-15
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
 * [Commit] [integration: refactor WebSocket integration utilities (#468)](https://github.com/erigontech/rpc-tests/commit/4f415d317dc3637648781b043ac3b002aa209132) - 2025-10-02
@@ -79,11 +79,11 @@ Team: [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=autho
 * [Commit] [integration: add integration utility for filter changes](https://github.com/erigontech/rpc-tests/commit/521776da2267952fc2c5b7fa411f0b7c92bc7a1c) - 2025-10-03
 * [Pull Request] [integration: input validation tests for eth_getStorageAt](https://github.com/erigontech/rpc-tests/pull/471) - 2025-10-04
 
-* [Pull Request] []() - 2025-12-06
+* [Pull Request] [docs: venv activation in README](https://github.com/erigontech/rpc-tests/pull/503) - 2025-12-06
 * [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-24
+* [Pull Request] [integration: fix tests for case block not found](https://github.com/erigontech/rpc-tests/pull/508) - 2025-12-24
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-10-16
+* [Pull Request] [clients/erigon: enable commitment history](https://github.com/ethereum/hive/pull/1355) - 2025-10-16
 ## Q3 2025
 
 

--- a/members/carlbeek.md
+++ b/members/carlbeek.md
@@ -12,8 +12,8 @@ Team: Consensus R&D (EF)
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-17
-* [Pull Request] []() - 2025-10-29
+* [Pull Request] [Update EIP-7773: PFI EIP-7708 in Glamsterdam](https://github.com/ethereum/EIPs/pull/10566) - 2025-10-17
+* [Pull Request] [Update EIP-7773: PFI 7686 for Glamsterdam](https://github.com/ethereum/EIPs/pull/10648) - 2025-10-29
 ## Q2 2025
 
 [ethereum/eips](https://github.com/ethereum/eips)

--- a/members/carsons-eels.md
+++ b/members/carsons-eels.md
@@ -13,3 +13,6 @@ Github: [@carsons-eels](https://github.com/carsons-eels)
 * [Issue] [Small update to 7708 EIP requires minor spec update](https://github.com/ethereum/execution-specs/issues/2088) - 2026-01-28
 * [Pull Request] [feat(tooling): auto-assign reviewers to PRs based on custom ranking](https://github.com/ethereum/execution-specs/pull/2467) - 2026-03-10
 * [Pull Request] [feat(tooling): align versioning scheme to 6.19.0](https://github.com/ethereum/execution-specs/pull/2464) - 2026-03-10
+* [Review] [Review on: refactor(spec-specs): add opcode gas constants](https://github.com/ethereum/execution-specs/pull/2396#pullrequestreview-3919228758) - 2026-03-10
+* [Review] [Review on: refactor(spec-specs): add opcode gas constants](https://github.com/ethereum/execution-specs/pull/2396#pullrequestreview-3919429636) - 2026-03-10
+* [Review] [Review on: refactor(spec-specs): add opcode gas constants](https://github.com/ethereum/execution-specs/pull/2396#pullrequestreview-3919477285) - 2026-03-10

--- a/members/carsons-eels.md
+++ b/members/carsons-eels.md
@@ -11,3 +11,5 @@ Github: [@carsons-eels](https://github.com/carsons-eels)
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Small update to 7708 EIP requires minor spec update](https://github.com/ethereum/execution-specs/issues/2088) - 2026-01-28
+* [Pull Request] [feat(tooling): auto-assign reviewers to PRs based on custom ranking](https://github.com/ethereum/execution-specs/pull/2467) - 2026-03-10
+* [Pull Request] [feat(tooling): align versioning scheme to 6.19.0](https://github.com/ethereum/execution-specs/pull/2464) - 2026-03-10

--- a/members/casparschwa.md
+++ b/members/casparschwa.md
@@ -12,7 +12,7 @@ Team: Robust Incentives Group (RIG)
 
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-09
+* [Pull Request] [Add Marios Ioannou to RIG](https://github.com/protocolguild/documentation/pull/466) - 2026-01-09
 * [Pull Request] []() - 2026-01-16
 ## Q3 2025
 

--- a/members/cbermudez97.md
+++ b/members/cbermudez97.md
@@ -12,15 +12,15 @@ Team: [NethermindEth contributions](https://github.com/cbermudez97?org=Nethermin
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-28
+* [Pull Request] [feat: enhance gas benchmark workflow with comments for start and results](https://github.com/NethermindEth/nethermind/pull/10350) - 2026-01-28
 ## Q4 2025
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2025-11-24
+* [Pull Request] [internal/debug: add support for grafana pyroscope sdk](https://github.com/ethereum/go-ethereum/pull/33261) - 2025-11-24
 
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2025-11-25
+* [Pull Request] [feat: enhance metrics and tracing support in benchmark scripts](https://github.com/NethermindEth/gas-benchmarks/pull/77) - 2025-11-25
 ## Q3 2025
 
 

--- a/members/cheatfate.md
+++ b/members/cheatfate.md
@@ -12,9 +12,9 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 
 
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-01-25
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [VC: Add option to publish all attestations for single slot in one call.](https://github.com/status-im/nimbus-eth2/pull/7874) - 2026-01-25
+* [Pull Request] [BN: New syncing algorithm](https://github.com/status-im/nimbus-eth2/pull/7921) - 2026-02-02
+* [Pull Request] [VC: More useful fork waiting log statement.](https://github.com/status-im/nimbus-eth2/pull/7963) - 2026-02-11
 ## Q4 2025
 
 
@@ -40,12 +40,12 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Commit] [Fix unnecessary imports.](https://github.com/status-im/nimbus-eth2/commit/c3c4b4cf9747ab5f8c5faa74110f3c7fd1a5da5f) - 2025-10-09
 * [Commit] [Missing sidecars helper functions.](https://github.com/status-im/nimbus-eth2/commit/71f84e79641777f502eaaa6d1b6c44cf12edca03) - 2025-10-10
 * [Commit] [Fix test_quarantine.](https://github.com/status-im/nimbus-eth2/commit/4421f49b86e016da0739d10791b986e2591bb3d8) - 2025-10-13
-* [Pull Request] []() - 2025-10-20
-* [Pull Request] []() - 2025-10-28
-* [Pull Request] []() - 2025-10-31
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-19
-* [Pull Request] []() - 2025-12-21
+* [Pull Request] [Add more helper functions to ColumnMap structure.](https://github.com/status-im/nimbus-eth2/pull/7632) - 2025-10-20
+* [Pull Request] [ColumnMap initialization](https://github.com/status-im/nimbus-eth2/pull/7672) - 2025-10-28
+* [Pull Request] [VC: Fix incorrect eth-consensus-version value when publishing attestations and aggregated attestations.](https://github.com/status-im/nimbus-eth2/pull/7689) - 2025-10-31
+* [Pull Request] [Add spamoor integration into finalization test.](https://github.com/status-im/nimbus-eth2/pull/7721) - 2025-11-07
+* [Pull Request] [Blob quarantine rewrite to get rid of busy loops.](https://github.com/status-im/nimbus-eth2/pull/7743) - 2025-11-19
+* [Pull Request] [VC: Add fallback mode for multiple beacon nodes.](https://github.com/status-im/nimbus-eth2/pull/7747) - 2025-12-21
 ## Q3 2025
 
 

--- a/members/cheeky-gorilla.md
+++ b/members/cheeky-gorilla.md
@@ -12,7 +12,7 @@ Team: [protocolguild/documentation](https://github.com/protocolguild/documentati
 
 
 [protocolguild/protocol-guild-site](https://github.com/protocolguild/protocol-guild-site)
-* [Pull Request] []() - 2026-02-02
+* [Pull Request] [Update DonorSectionDark2.tsx](https://github.com/protocolguild/protocol-guild-site/pull/45) - 2026-02-02
 ## Q4 2025
 
 

--- a/members/chfast.md
+++ b/members/chfast.md
@@ -14,39 +14,47 @@ Team: [ethereum/evmone](https://github.com/ethereum/evmone/commits?author=chfast
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [legacytests contain invalid pre Spurious Dragon state tests](https://github.com/ethereum/execution-specs/issues/1967) - 2026-01-05
 
-* [Pull Request] []() - 2026-01-17
+* [Pull Request] [feat(tests): port EXTCODEHASH dynamicAccountOverwriteEmpty](https://github.com/ethereum/execution-specs/pull/2032) - 2026-01-17
 * [Issue] [Add tests for "reverted touch of empty account"](https://github.com/ethereum/execution-specs/issues/2174) - 2026-02-09
 * [Issue] [Zero test for Tangerine Whistle / Spurious Dragon / Constantinople](https://github.com/ethereum/execution-specs/issues/2173) - 2026-02-09
 * [Issue] [Missing test case for EIP-7702](https://github.com/ethereum/execution-specs/issues/2177) - 2026-02-10
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [chore(tests): remove ported static eip-1153 transient storage tests](https://github.com/ethereum/execution-specs/pull/2385) - 2026-03-02
 * [Issue] [codecov: use separate flags for main/internal/static tests](https://github.com/ethereum/execution-specs/issues/2382) - 2026-03-02
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [feat(tests): add ecrecover tests for combined invalid r and s values](https://github.com/ethereum/execution-specs/pull/2440) - 2026-03-06
+* [Pull Request] [feat(tests): port codeCopyZero and delete stExtCodeHash static tests](https://github.com/ethereum/execution-specs/pull/2465) - 2026-03-10
+* [Pull Request] [refactor(testing): rename empty_account() to nonexistent_account()](https://github.com/ethereum/execution-specs/pull/2462) - 2026-03-10
+* [Pull Request] [chore(tests): delete already-ported extCodeHash static file](https://github.com/ethereum/execution-specs/pull/2463) - 2026-03-10
+* [Pull Request] [feat(tests): port EXTCODEHASH subcall CREATE2 OOG test](https://github.com/ethereum/execution-specs/pull/2458) - 2026-03-10
+* [Commit] [feat(tests): port codeCopyZero and delete stExtCodeHash static tests (#2465)](https://github.com/ethereum/execution-specs/commit/6df036c96221184e277a9818fb43639d40e9036b) - 2026-03-10
+* [Commit] [refactor(testing): rename empty_account() to nonexistent_account() (#2462)](https://github.com/ethereum/execution-specs/commit/46aa9345424a15c932612f43b91ae906523767b0) - 2026-03-10
+* [Commit] [chore(tests): delete already-ported extCodeHash static file (#2463)](https://github.com/ethereum/execution-specs/commit/525810670fd06f1ff228f8514e41a76c340def78) - 2026-03-10
+* [Commit] [feat(tests): port EXTCODEHASH subcall CREATE2 OOG test (#2458)](https://github.com/ethereum/execution-specs/commit/ae78d8ab2332c4a0c7acc166850ab013b511f8bd) - 2026-03-10
 [ethereum/evmone](https://github.com/ethereum/evmone)
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [ci: Upgrade riscv toolchain and harden curl downloads](https://github.com/ipsilon/evmone/pull/1418) - 2026-01-06
+* [Pull Request] [test: Add modexp test vectors for even modulus and edge cases](https://github.com/ipsilon/evmone/pull/1421) - 2026-01-15
 * [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [crypto: Handle modexp with exponent of 1 separately](https://github.com/ipsilon/evmone/pull/1424) - 2026-01-26
+* [Pull Request] [crypto: Use Almost Montgomery Multiplication in modexp](https://github.com/ipsilon/evmone/pull/1427) - 2026-01-27
+* [Pull Request] [tidy: Make bool → int conversion explicit](https://github.com/ipsilon/evmone/pull/1431) - 2026-01-30
+* [Pull Request] [test: Extend modexp benchmarks](https://github.com/ipsilon/evmone/pull/1433) - 2026-02-02
+* [Pull Request] [crypto: Extract `addmul()` helper in modexp](https://github.com/ipsilon/evmone/pull/1436) - 2026-02-03
+* [Pull Request] [Fix missing #include <evmc/evmc.hpp>](https://github.com/ipsilon/evmone/pull/1437) - 2026-02-04
+* [Pull Request] [ci: Upgrade compilers and build images](https://github.com/ipsilon/evmone/pull/1441) - 2026-02-05
+* [Pull Request] [crypto: Rewrite modexp_even to use variadic-length numbers](https://github.com/ipsilon/evmone/pull/1443) - 2026-02-06
 * [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-14
+* [Pull Request] [test: Add modexp test cases for modulus 0–1](https://github.com/ipsilon/evmone/pull/1445) - 2026-02-09
+* [Pull Request] [Fix missing EIP-7702 y_parity validation](https://github.com/ipsilon/evmone/pull/1450) - 2026-02-10
+* [Pull Request] [crypto: Update modexp to use variadic-length numbers (except odd)](https://github.com/ipsilon/evmone/pull/1452) - 2026-02-12
+* [Pull Request] [precompiles: Remove modexp stubs, use local impl for all inputs](https://github.com/ipsilon/evmone/pull/1453) - 2026-02-13
+* [Pull Request] [precompiles: Add option to use libsecp256k1](https://github.com/ipsilon/evmone/pull/1454) - 2026-02-14
 * [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [precompiles: Remove optional "silkpre" backend](https://github.com/ipsilon/evmone/pull/1456) - 2026-02-17
+* [Pull Request] [crypto: Compute modexp base_mont using var-length division](https://github.com/ipsilon/evmone/pull/1457) - 2026-02-18
+* [Pull Request] [precompiles: Tests for huge inputs to expmod](https://github.com/ipsilon/evmone/pull/1459) - 2026-02-24
+* [Pull Request] [crypto: Refactor modexp/mul_amm to use std::span params](https://github.com/ipsilon/evmone/pull/1460) - 2026-02-25
+* [Pull Request] [crypto: Use dynamic spans in modexp_odd and mul_amm](https://github.com/ipsilon/evmone/pull/1462) - 2026-03-03
+* [Pull Request] [changelog: List changes for 0.19 release](https://github.com/ipsilon/evmone/pull/1463) - 2026-03-04
+* [Pull Request] [crypto: Use exact size for x1 in modexp_even CRT](https://github.com/ipsilon/evmone/pull/1465) - 2026-03-09
 ## Q4 2025
 
 
@@ -55,11 +63,11 @@ Team: [ethereum/evmone](https://github.com/ethereum/evmone/commits?author=chfast
 * [Commit] [crypto: Fix handling of the input point-at-infinity in secp256r1](https://github.com/ipsilon/evmone/commit/25898a412f5c4ac43d9a01be17cede68dfad5c8c) - 2025-10-01
 
 * [Pull Request] [crypto: Optimize bit test of scalar in ECC multiplication](https://github.com/ipsilon/evmone/pull/1336) - 2025-10-13
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-21
+* [Pull Request] [test: Disallow empty storage values in MTP hash](https://github.com/ipsilon/evmone/pull/1366) - 2025-11-07
+* [Pull Request] [test: Add even modexp unit tests with long trailing zeros](https://github.com/ipsilon/evmone/pull/1368) - 2025-11-12
+* [Pull Request] [crypto: Detect EC point doubling more efficiently](https://github.com/ipsilon/evmone/pull/1392) - 2025-12-02
+* [Pull Request] [test: In state test do block post-processing only for valid transaction](https://github.com/ipsilon/evmone/pull/1395) - 2025-12-08
+* [Pull Request] [tests: Update modexp benchmarks to Osaka gas prices](https://github.com/ipsilon/evmone/pull/1410) - 2025-12-21
 [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests)
 * [Pull Request] [feat(tests): add test for modexp with 2**32 exp len](https://github.com/ethereum/execution-spec-tests/pull/2254) - 2025-10-02
 
@@ -67,7 +75,7 @@ Team: [ethereum/evmone](https://github.com/ethereum/evmone/commits?author=chfast
 * [Issue] [`Storage.KeyValueMismatch` is broken](https://github.com/ethereum/execution-specs/issues/1483) - 2025-10-09
 * [Issue] [Port evmone test cases](https://github.com/ethereum/execution-specs/issues/1470) - 2025-10-09
 * [Issue] [Analysis of Osaka test coverage based on evmone implementation](https://github.com/ethereum/execution-specs/issues/1614) - 2025-10-16
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [feat(tests): add new critical test cases for BN254 input validation](https://github.com/ethereum/execution-specs/pull/1948) - 2025-12-23
 * [Pull Request] []() - 2025-12-25
 ## Q3 2025
 

--- a/members/chong-he.md
+++ b/members/chong-he.md
@@ -11,3 +11,5 @@ Github: [@chong-he](https://github.com/chong-he)
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
 * [Issue] [Implement `/eth/v1/beacon/states/{state_id}/proposer_lookahead` endpoint](https://github.com/sigp/lighthouse/issues/8809) - 2026-02-12
+* [Review] [Review on: Implement proposer lookahead endpoint](https://github.com/sigp/lighthouse/pull/8815#pullrequestreview-3922147451) - 2026-03-10
+* [Review] [Review on: Implement proposer lookahead endpoint](https://github.com/sigp/lighthouse/pull/8815#pullrequestreview-3922150102) - 2026-03-10

--- a/members/cperezz.md
+++ b/members/cperezz.md
@@ -10,9 +10,9 @@ Github: [@cperezz](https://github.com/cperezz)
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-02-14
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [core/types: fix CopyHeader missing BlockAccessListHash deep copy](https://github.com/ethereum/go-ethereum/pull/33844) - 2026-02-14
+* [Pull Request] [eth/protocols/snap: restore peers to idle pool on request revert](https://github.com/ethereum/go-ethereum/pull/33790) - 2026-02-24
 
 [gballet/go-ethereum](https://github.com/gballet/go-ethereum)
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569) - 2026-02-25
+* [Pull Request] [cmd, core: wire --bintrie.groupdepth flag to SetEthConfig](https://github.com/gballet/go-ethereum/pull/571) - 2026-03-05* [Pull Request] [trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569) - 2026-03-10

--- a/members/cperezz.md
+++ b/members/cperezz.md
@@ -16,3 +16,8 @@ Github: [@cperezz](https://github.com/cperezz)
 [gballet/go-ethereum](https://github.com/gballet/go-ethereum)
 * [Pull Request] [trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569) - 2026-02-25
 * [Pull Request] [cmd, core: wire --bintrie.groupdepth flag to SetEthConfig](https://github.com/gballet/go-ethereum/pull/571) - 2026-03-05* [Pull Request] [trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569) - 2026-03-10
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3922524497) - 2026-03-10
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3922526172) - 2026-03-10
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3922527866) - 2026-03-10
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3922532989) - 2026-03-10
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3922538292) - 2026-03-10

--- a/members/cperezz.md
+++ b/members/cperezz.md
@@ -16,3 +16,4 @@ Github: [@cperezz](https://github.com/cperezz)
 [gballet/go-ethereum](https://github.com/gballet/go-ethereum)
 * [Pull Request] []() - 2026-02-25
 * [Pull Request] []() - 2026-03-05
+* [Pull Request] []() - 2026-03-10

--- a/members/cskiraly.md
+++ b/members/cskiraly.md
@@ -12,15 +12,15 @@ Team: Codex DAS
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-14
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-20
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [eth: txs fetch/send log at trace level only](https://github.com/ethereum/go-ethereum/pull/33541) - 2026-01-07
+* [Pull Request] [core: remove duplicate chainHeadFeed.Send code](https://github.com/ethereum/go-ethereum/pull/33563) - 2026-01-09
+* [Pull Request] [eth: check for tx on chain as well (v2)](https://github.com/ethereum/go-ethereum/pull/33607) - 2026-01-14
+* [Pull Request] [core/txpool/legacypool: add metric for accounts in txpool ](https://github.com/ethereum/go-ethereum/pull/33646) - 2026-01-19
+* [Pull Request] [core/txpool/legacypool: reset gauges on clear](https://github.com/ethereum/go-ethereum/pull/33654) - 2026-01-20
+* [Pull Request] [core/txpool/legacypool: clarify and fix non-executable tx heartbeat](https://github.com/ethereum/go-ethereum/pull/33704) - 2026-01-28
+* [Pull Request] [common/lru: add metered lru cache variant](https://github.com/ethereum/go-ethereum/pull/33719) - 2026-01-29
+* [Pull Request] [metrics: allow changing influxdb interval](https://github.com/ethereum/go-ethereum/pull/33767) - 2026-02-05
+* [Pull Request] [core/txpool/blobpool: delay announcement of low fee txs](https://github.com/ethereum/go-ethereum/pull/33893) - 2026-02-26
 ## Q4 2025
 
 
@@ -29,15 +29,15 @@ Team: Codex DAS
 * [Commit] [core/txpool/legacypool: move queue out of main txpool (#32270)](https://github.com/ethereum/go-ethereum/commit/7b693ea17c9e5e950a36df29262fab7862ffda23) - 2025-10-13
 * [Pull Request] [eth: do not warn on switching from snap sync to full sync](https://github.com/ethereum/go-ethereum/pull/32900) - 2025-10-13
 
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-11-15
+* [Pull Request] [core/txpool/blobpool: fix benchmarkPoolPending](https://github.com/ethereum/go-ethereum/pull/33161) - 2025-11-12
+* [Pull Request] [eth/catalyst: benchmark GetBlobsV2 at API level](https://github.com/ethereum/go-ethereum/pull/33196) - 2025-11-15
 * [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-22
+* [Pull Request] [core/txpool/blobpool: fix slotter size limit](https://github.com/ethereum/go-ethereum/pull/33474) - 2025-12-22
 * [Pull Request] []() - 2025-12-24
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-29
-* [Pull Request] []() - 2025-12-05
+* [Pull Request] [Add EIP: eth/XX - announce transactions with nonce](https://github.com/ethereum/EIPs/pull/10745) - 2025-11-07
+* [Pull Request] [Add EIP: eth/vhash - Blob-Aware Mempool](https://github.com/ethereum/EIPs/pull/10853) - 2025-11-29
+* [Pull Request] [Update EIP-8077: improved rationale](https://github.com/ethereum/EIPs/pull/10873) - 2025-12-05
 ## Q3 2025
 
 

--- a/members/damian-orzechowski.md
+++ b/members/damian-orzechowski.md
@@ -12,7 +12,7 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2025-11-07
+* [Pull Request] [Fix free disk space check for non existent directories (HealthChecks)](https://github.com/NethermindEth/nethermind/pull/9666) - 2025-11-07
 ## Q3 2025
 
 

--- a/members/danceratopz.md
+++ b/members/danceratopz.md
@@ -12,21 +12,21 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [chore(test-*): fix typos in `packages/testing/`](https://github.com/ethereum/execution-specs/pull/1969) - 2026-01-06
 * [Issue] [Update 2026 EIP Championing Document with news docs link](https://github.com/ethereum/execution-specs/issues/1994) - 2026-01-08
-* [Pull Request] []() - 2026-01-08
+* [Pull Request] [chore(test-fill): fix pytest warnings in console test summary](https://github.com/ethereum/execution-specs/pull/1993) - 2026-01-08
 * [Issue] [Automate cold-access transaction splitting for stateful benchmarks](https://github.com/ethereum/execution-specs/issues/1991) - 2026-01-08
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [fix(test-tests): prevent race condition in gentest tests w/xdist](https://github.com/ethereum/execution-specs/pull/2009) - 2026-01-12
+* [Pull Request] [chore(tooling): add initial claude config and skills](https://github.com/ethereum/execution-specs/pull/2024) - 2026-01-14
 
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [feat(test-fill,test-specs): add t8n call caching to test specs](https://github.com/ethereum/execution-specs/pull/2084) - 2026-01-27
 * [Issue] [Reduce memory when merging partial fixture files](https://github.com/ethereum/execution-specs/issues/2123) - 2026-02-03
 * [Pull Request] []() - 2026-02-08
 * [Issue] [Add heuristic to determine xdist worker count in `pytest_xdist_auto_num_workers`](https://github.com/ethereum/execution-specs/issues/2163) - 2026-02-09
 * [Issue] [Enable t8n caching for state_test on Paris/Shanghai](https://github.com/ethereum/execution-specs/issues/2225) - 2026-02-17
 * [Issue] [Consider reducing fixture size for `account_query` (16 GB) and `unchunkified_bytecode` (13 GB)](https://github.com/ethereum/execution-specs/issues/2223) - 2026-02-17
 * [Issue] [Use historically-accurate per-fork block gas limits](https://github.com/ethereum/execution-specs/issues/2230) - 2026-02-18
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [feat(test-fixtures): add BlockchainEngineStatefulFixture format](https://github.com/ethereum/execution-specs/pull/2169) - 2026-02-20
 * [Issue] [Also, as this file is...](https://github.com/ethereum/execution-specs/issues/2284) - 2026-02-23
 * [Issue] [Improve branch documentation (also for packages/testing contributions)](https://github.com/ethereum/execution-specs/issues/2278) - 2026-02-23
 * [Issue] [Bump default uv version used in CI](https://github.com/ethereum/execution-specs/issues/2324) - 2026-02-25
@@ -37,12 +37,15 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [Add possibility to dry-run CI without the uv cache](https://github.com/ethereum/execution-specs/issues/2376) - 2026-03-01
 * [Issue] [Re-enable `test_get_blobs` in devnet tests/`hiveview`](https://github.com/ethereum/execution-specs/issues/2391) - 2026-03-03
 * [Issue] [Add `execute hive` System Test to CI](https://github.com/ethereum/execution-specs/issues/2390) - 2026-03-03
+* [Pull Request] [feat(test-consume): initial implementation of the enginex simulator](https://github.com/ethereum/execution-specs/pull/1964) - 2026-03-10
+* [Commit] [feat(test-consume): initial implementation of the enginex simulator (#1964)](https://github.com/ethereum/execution-specs/commit/212389ab07088d68556bc488a9d6b356b7c6a4cb) - 2026-03-10
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-23
+* [Pull Request] [Add Leo from STEEL, ethereum/consensus-specs](https://github.com/protocolguild/documentation/pull/471) - 2026-01-23
 
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [fix: switch erigon dockerfiles from Alpine to Debian](https://github.com/ethereum/hive/pull/1390) - 2026-02-23
 
+* [Pull Request] [hivesim,libhive,simulators/ethereum/engine: apply gofmt; clean-up whitespace](https://github.com/ethereum/hive/pull/1401) - 2026-03-10
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [All Core Devs - Testing (ACDT) #73, March 9, 2026](https://github.com/ethereum/pm/issues/1956) - 2026-03-03
 ## Q4 2025
@@ -54,7 +57,7 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 
 * [Pull Request] [Use non-editable installs for test generators](https://github.com/ethereum/consensus-specs/pull/4634) - 2025-10-03
 * [Issue] [Editable installs + multiprocessing break vector generation](https://github.com/ethereum/consensus-specs/issues/4633) - 2025-10-03
-* [Pull Request] []() - 2025-10-21
+* [Pull Request] [Always reinstall `eth2spec` for non-editable installs](https://github.com/ethereum/consensus-specs/pull/4676) - 2025-10-21
 [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests)
 * [Commit] [Deployed 28ca6decef3 to main with MkDocs 1.6.1 and mike 1.1.2](https://github.com/ethereum/execution-spec-tests/commit/e4b71f3c74639dd3b2b475f32b3e0828036f05f1) - 2025-10-02
 * [Commit] [Deployed ae9b597612c to main with MkDocs 1.6.1 and mike 1.1.2](https://github.com/ethereum/execution-spec-tests/commit/1d57fb4149540151a16a025783f76eff24439df4) - 2025-10-02
@@ -102,23 +105,23 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [feat(evm): add extended tracing to ethereum-spec-evm t8n interface](https://github.com/ethereum/execution-specs/issues/1468) - 2025-10-09
 * [Issue] [bug(gentest,rpc): `gentest` rpc error with `unexpected keyword argument 'extra_headers'`](https://github.com/ethereum/execution-specs/issues/1623) - 2025-10-16
 * [Issue] [feat(fill,execute,benchmark): test selection via pytest's `testpaths` instead of markers via `--mode`](https://github.com/ethereum/execution-specs/issues/1616) - 2025-10-16
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [refactor(testing): improve layout and naming of `testing` packages](https://github.com/ethereum/execution-specs/pull/1654) - 2025-10-22
 * [Issue] [Reduce HTML file size in the reference test documentation](https://github.com/ethereum/execution-specs/issues/1662) - 2025-10-23
 * [Issue] [Running `fill` generates `PytestAssertRewriteWarning` for `custom_logging` plugin](https://github.com/ethereum/execution-specs/issues/1676) - 2025-10-24
 * [Issue] [Ensure `uv run eest make test` calls `ruff` and formats the generated test module correctly](https://github.com/ethereum/execution-specs/issues/1675) - 2025-10-24
 * [Issue] [Fix target directory for `env.yaml` with `eest make env` when ran from package](https://github.com/ethereum/execution-specs/issues/1674) - 2025-10-24
 * [Issue] [Update documentation for testing Package Renaming (Follow-up to PR #1654)](https://github.com/ethereum/execution-specs/issues/1672) - 2025-10-24
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [chore(deps,tooling): move `dev` extras to `dependency-group`](https://github.com/ethereum/execution-specs/pull/1688) - 2025-10-27
 * [Issue] [Don't format generated code from `gentest` and `eest make test` if `ruff` is not present](https://github.com/ethereum/execution-specs/issues/1715) - 2025-10-29
 * [Issue] [Update docs for the change from `optional-dependencies` (extras) to `dependency_groups`](https://github.com/ethereum/execution-specs/issues/1713) - 2025-10-29
 * [Issue] [chore(docs): re-enable benchmark test documentation](https://github.com/ethereum/execution-specs/issues/1756) - 2025-11-05
 * [Issue] [Add versioning for mkdocs pages and rendered spec](https://github.com/ethereum/execution-specs/issues/1772) - 2025-11-11
-* [Pull Request] []() - 2025-11-16
+* [Pull Request] [fix(ci): fix hive config file path action](https://github.com/ethereum/execution-specs/pull/1796) - 2025-11-16
 
 * [Issue] [Augment `BenchmarkTestFiller` with opcode under test and its expected count](https://github.com/ethereum/execution-specs/issues/1835) - 2025-12-03
 * [Issue] [Review and remove (or port?) static transient storage test cases](https://github.com/ethereum/execution-specs/issues/1957) - 2025-12-30
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-11-19
+* [Pull Request] [Update EIP-7723: Update to reflect that execution-spec-tests no longer accepts PRs](https://github.com/ethereum/EIPs/pull/10814) - 2025-11-19
 ## Q3 2025
 
 

--- a/members/danceratopz.md
+++ b/members/danceratopz.md
@@ -39,6 +39,7 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [Add `execute hive` System Test to CI](https://github.com/ethereum/execution-specs/issues/2390) - 2026-03-03
 * [Pull Request] [feat(test-consume): initial implementation of the enginex simulator](https://github.com/ethereum/execution-specs/pull/1964) - 2026-03-10
 * [Commit] [feat(test-consume): initial implementation of the enginex simulator (#1964)](https://github.com/ethereum/execution-specs/commit/212389ab07088d68556bc488a9d6b356b7c6a4cb) - 2026-03-10
+* [Review] [Review on: feat(test-consume): initial implementation of the enginex simulator](https://github.com/ethereum/execution-specs/pull/1964#pullrequestreview-3923666913) - 2026-03-10
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] [Add Leo from STEEL, ethereum/consensus-specs](https://github.com/protocolguild/documentation/pull/471) - 2026-01-23
 

--- a/members/danceratopz.md
+++ b/members/danceratopz.md
@@ -43,6 +43,7 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 [ethereum/hive](https://github.com/ethereum/hive)
 * [Pull Request] []() - 2026-02-23
 
+* [Pull Request] []() - 2026-03-10
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [All Core Devs - Testing (ACDT) #73, March 9, 2026](https://github.com/ethereum/pm/issues/1956) - 2026-03-03
 ## Q4 2025

--- a/members/daniellehrner.md
+++ b/members/daniellehrner.md
@@ -27,6 +27,9 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ada
 * [Pull Request] [Check new files for the correct copyright header in th CI](https://github.com/besu-eth/besu/pull/10012) - 2026-03-10
 * [Pull Request] [Merge streaming tracer into bal-devnet-2-with-prefetch](https://github.com/besu-eth/besu/pull/10013) - 2026-03-10
 * [Pull Request] [Merge trace-streaming into bal-devnet-2](https://github.com/besu-eth/besu/pull/10011) - 2026-03-10
+* [Review] [Review on: Add compressed ECDH key agreement to SecurityModule](https://github.com/besu-eth/besu/pull/10007#pullrequestreview-3921584445) - 2026-03-10
+* [Review] [Review on: Amsterdam: EIP-8037: State Creation Gas Cost Increase](https://github.com/besu-eth/besu/pull/9815#pullrequestreview-3922851620) - 2026-03-10
+* [Review] [Review on: Amsterdam: EIP-8037: State Creation Gas Cost Increase](https://github.com/besu-eth/besu/pull/9815#pullrequestreview-3922853309) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/daniellehrner.md
+++ b/members/daniellehrner.md
@@ -12,28 +12,31 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ada
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-01-14
-* [Pull Request] []() - 2026-01-22
+* [Pull Request] [EIP 7843: SLOTNUM op code](https://github.com/besu-eth/besu/pull/9632) - 2026-01-13
+* [Pull Request] [Use bonsai code cache in ExtCodeSizeOperation](https://github.com/besu-eth/besu/pull/9634) - 2026-01-14
+* [Pull Request] [EIP-7708: Add SELFDESTRUCT log for self transfer and remaining balance at the transaction end](https://github.com/besu-eth/besu/pull/9672) - 2026-01-22
 * [Issue] [Remove tx receipt changes from EIP-7778](https://github.com/hyperledger/besu/issues/9683) - 2026-01-26
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-01
+* [Pull Request] [Add devnet reference tests and change naming to allow filtering per hardfork or eip number](https://github.com/besu-eth/besu/pull/9698) - 2026-01-27
+* [Pull Request] [EIP-7708: ignore self transfers](https://github.com/besu-eth/besu/pull/9717) - 2026-01-30
+* [Pull Request] [EIP-7778: remove tx receipt changes](https://github.com/besu-eth/besu/pull/9715) - 2026-02-01
 * [Issue] [Amsterdam: EIP-7954: Increase Maximum Contract Size](https://github.com/hyperledger/besu/issues/9816) - 2026-02-16
 * [Issue] [Amsterdam: eth_simulateV1: fix revert err code](https://github.com/hyperledger/besu/issues/9829) - 2026-02-17
 * [Issue] [Update EIP-8024: Switch to branchless normalization and extend EXCHANGE](https://github.com/hyperledger/besu/issues/9827) - 2026-02-17
 * [Issue] [Update EIP-7708: Add ETH burn logs](https://github.com/hyperledger/besu/issues/9826) - 2026-02-17
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [Use sha256 hardware implementation](https://github.com/besu-eth/besu/pull/9924) - 2026-02-28
+* [Pull Request] [Check new files for the correct copyright header in th CI](https://github.com/besu-eth/besu/pull/10012) - 2026-03-10
+* [Pull Request] [Merge streaming tracer into bal-devnet-2-with-prefetch](https://github.com/besu-eth/besu/pull/10013) - 2026-03-10
+* [Pull Request] [Merge trace-streaming into bal-devnet-2](https://github.com/besu-eth/besu/pull/10011) - 2026-03-10
 ## Q4 2025
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [Parse Geth genesis file](https://github.com/besu-eth/besu/pull/9368) - 2025-10-27
 * [Issue] [EIP-8024: Backward compatible SWAPN, DUPN, EXCHANGE](https://github.com/hyperledger/besu/issues/9542) - 2025-12-05
 * [Issue] [EIP-7843: SLOTNUM opcode](https://github.com/hyperledger/besu/issues/9541) - 2025-12-05
 * [Issue] [EIP-7708: ETH transfers emit a log](https://github.com/hyperledger/besu/issues/9540) - 2025-12-05
 * [Issue] [EIP-7778: Block Gas Accounting without Refunds](https://github.com/hyperledger/besu/issues/9539) - 2025-12-05
-* [Pull Request] []() - 2025-12-10
+* [Pull Request] [Remove EOF](https://github.com/besu-eth/besu/pull/9559) - 2025-12-10
 ## Q3 2025
 
 

--- a/members/danipopes.md
+++ b/members/danipopes.md
@@ -38,6 +38,7 @@ Team: Reth
 [paradigmxyz/revmc](https://github.com/paradigmxyz/revmc)
 * [Pull Request] []() - 2026-03-05
 * [Pull Request] []() - 2026-03-07
+* [Pull Request] []() - 2026-03-10
 ## Q4 2025
 
 

--- a/members/danipopes.md
+++ b/members/danipopes.md
@@ -12,49 +12,61 @@ Team: Reth
 
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-08
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-14
-* [Pull Request] []() - 2026-01-19
+* [Pull Request] [fix(bench-compare): add backward compat for old CSV format](https://github.com/paradigmxyz/reth/pull/20754) - 2026-01-05
+* [Pull Request] [chore(rbc): improve compilation log message](https://github.com/paradigmxyz/reth/pull/20855) - 2026-01-08
+* [Pull Request] [perf(db): throttle metrics reporting](https://github.com/paradigmxyz/reth/pull/20974) - 2026-01-12
+* [Pull Request] [refactor(db): return Result<()> from DbTx::commit](https://github.com/paradigmxyz/reth/pull/21085) - 2026-01-14
+* [Pull Request] [ci: update to tempoxyz](https://github.com/paradigmxyz/reth/pull/21176) - 2026-01-19
 
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [chore(deps): breaking bumps](https://github.com/paradigmxyz/reth/pull/21584) - 2026-01-31
+* [Pull Request] [chore: match statement order in ExecutionCache::new](https://github.com/paradigmxyz/reth/pull/21712) - 2026-02-02
+* [Pull Request] [chore(engine): remove MIN_WORKER_COUNT](https://github.com/paradigmxyz/reth/pull/21829) - 2026-02-04
 * [Issue] [test tmpdirs are not cleaned up](https://github.com/paradigmxyz/reth/issues/21769) - 2026-02-03
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-16
+* [Pull Request] [feat: thread-local ConsistentProvider cache for BlockchainProvider](https://github.com/paradigmxyz/reth/pull/22112) - 2026-02-12
+* [Pull Request] [perf: use mutex in for_each_ordered](https://github.com/paradigmxyz/reth/pull/22252) - 2026-02-16
 * [Issue] [Use Withdrawals instead of Vec<Withdrawal>](https://github.com/paradigmxyz/reth/issues/22362) - 2026-02-19
-* [Pull Request] []() - 2026-02-28
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [chore: use different pool for tx recovery](https://github.com/paradigmxyz/reth/pull/22588) - 2026-02-28
+* [Pull Request] [chore: improve long read tx log](https://github.com/paradigmxyz/reth/pull/22716) - 2026-03-02
+* [Pull Request] [feat: enable PGO in release and docker workflows](https://github.com/paradigmxyz/reth/pull/21441) - 2026-03-10
+* [Pull Request] [chore: silence arena trie warning](https://github.com/paradigmxyz/reth/pull/22928) - 2026-03-10
+* [Pull Request] [chore: rm thunderdome refs](https://github.com/paradigmxyz/reth/pull/22927) - 2026-03-10
+* [Commit] [feat: enable PGO in release and docker workflows (#21441)](https://github.com/paradigmxyz/reth/commit/e63ebac38043c3cb1dcc7c7b5ae28245b91f3416) - 2026-03-10
+* [Commit] [chore: rm thunderdome refs (#22927)](https://github.com/paradigmxyz/reth/commit/01bd1cc5fa87b2ff58644b26c2fdc607662ef9ad) - 2026-03-10
 [bluealloy/revm](https://github.com/bluealloy/revm)
-* [Pull Request] []() - 2026-01-23
+* [Pull Request] [perf: elide some jumps in jump](https://github.com/bluealloy/revm/pull/3347) - 2026-01-23
 * [Pull Request] []() - 2026-01-25
 * [Issue] [perf: collect in apply_account_state is wasteful](https://github.com/bluealloy/revm/issues/3374) - 2026-01-30
-* [Pull Request] []() - 2026-01-30
+* [Pull Request] [refactor!: flatten Bytecode](https://github.com/bluealloy/revm/pull/3375) - 2026-01-30
 * [Pull Request] []() - 2026-02-05
 
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [chore(revme): use alloy-trie instead of triehash](https://github.com/bluealloy/revm/pull/3488) - 2026-03-09
 [paradigmxyz/revmc](https://github.com/paradigmxyz/revmc)
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-07
+* [Pull Request] [fix: make state tests pass](https://github.com/paradigmxyz/revmc/pull/95) - 2026-03-05
+* [Pull Request] [fix: remove flaky builtin_symbols_exported test](https://github.com/paradigmxyz/revmc/pull/108) - 2026-03-07
+* [Pull Request] [chore(deps): breaking bumps](https://github.com/paradigmxyz/revmc/pull/123) - 2026-03-10
+* [Pull Request] [ci: run statetests on macos](https://github.com/paradigmxyz/revmc/pull/122) - 2026-03-10
+* [Pull Request] [ci: update names](https://github.com/paradigmxyz/revmc/pull/112) - 2026-03-10
+* [Pull Request] [feat: reduce memory usage further](https://github.com/paradigmxyz/revmc/pull/121) - 2026-03-10
+* [Commit] [chore(deps): breaking bumps (#123)](https://github.com/paradigmxyz/revmc/commit/08699c3af876a9bfc7484516c9ae9d3079740e54) - 2026-03-10
+* [Commit] [ci: update names (#112)](https://github.com/paradigmxyz/revmc/commit/c5b170830aad3a31705b2c590b43b9c33919760d) - 2026-03-10
+* [Commit] [feat: reduce memory usage further (#121)](https://github.com/paradigmxyz/revmc/commit/26a4c5f246b4b97067afd32df246ee8fe7e219e8) - 2026-03-10
 ## Q4 2025
 
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
 * [Pull Request] [ci: cache zepter installation](https://github.com/paradigmxyz/reth/pull/18843) - 2025-10-02
 
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-15
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [ci: add more sccache](https://github.com/paradigmxyz/reth/pull/20316) - 2025-12-11
+* [Pull Request] [ci: trim docs job](https://github.com/paradigmxyz/reth/pull/20381) - 2025-12-15
+* [Pull Request] [chore: simplify execution state providers](https://github.com/paradigmxyz/reth/pull/20444) - 2025-12-16
+* [Pull Request] [chore: simplify prewarm state providers](https://github.com/paradigmxyz/reth/pull/20469) - 2025-12-17
 * [Issue] [Remove deprecated lighthouse flag](https://github.com/paradigmxyz/reth/issues/20579) - 2025-12-23
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [feat: switch samply feature for CLI flags](https://github.com/paradigmxyz/reth/pull/20586) - 2025-12-23
 * [Pull Request] []() - 2025-12-27
 [bluealloy/revm](https://github.com/bluealloy/revm)
 * [Pull Request] [perf: resize short addresses bitvec instead of reallocating](https://github.com/bluealloy/revm/pull/3083) - 2025-10-11
 * [Issue] [`memory_limit` cfg is not hooked up to `SharedMemory`](https://github.com/bluealloy/revm/issues/3127) - 2025-10-27
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [fix: hook up Cfg::memory_limit](https://github.com/bluealloy/revm/pull/3129) - 2025-10-28
 * [Issue] [Cache CreateInputs::created_address](https://github.com/bluealloy/revm/issues/3217) - 2025-12-10
 ## Q3 2025
 

--- a/members/danipopes.md
+++ b/members/danipopes.md
@@ -32,6 +32,22 @@ Team: Reth
 * [Pull Request] [chore: rm thunderdome refs](https://github.com/paradigmxyz/reth/pull/22927) - 2026-03-10
 * [Commit] [feat: enable PGO in release and docker workflows (#21441)](https://github.com/paradigmxyz/reth/commit/e63ebac38043c3cb1dcc7c7b5ae28245b91f3416) - 2026-03-10
 * [Commit] [chore: rm thunderdome refs (#22927)](https://github.com/paradigmxyz/reth/commit/01bd1cc5fa87b2ff58644b26c2fdc607662ef9ad) - 2026-03-10
+* [Review] [Review on: fix(codecs): return advanced buf from AlloyHeader::from_compact](https://github.com/paradigmxyz/reth/pull/22931#pullrequestreview-3925574826) - 2026-03-10
+* [Review] [Review on: perf(engine): replace moka with schnellru for precompile cache and add per-precompile sizing](https://github.com/paradigmxyz/reth/pull/22900#pullrequestreview-3921584032) - 2026-03-10
+* [Review] [Review on: fix(ci): remove hashing stages from stage-run-test for storage v2](https://github.com/paradigmxyz/reth/pull/22929#pullrequestreview-3924963475) - 2026-03-10
+* [Review] [Review on: perf(engine): hoist outer map lookups out of per-slot loops](https://github.com/paradigmxyz/reth/pull/22875#pullrequestreview-3921542249) - 2026-03-10
+* [Review] [Review on: perf(engine): hoist outer map lookups out of per-slot loops](https://github.com/paradigmxyz/reth/pull/22875#pullrequestreview-3924968389) - 2026-03-10
+* [Review] [Review on: fix(ci): remove issue_comment: edited from bench trigger](https://github.com/paradigmxyz/reth/pull/22925#pullrequestreview-3923628341) - 2026-03-10
+* [Review] [Review on: test(trie): Implement TrieTestHarness](https://github.com/paradigmxyz/reth/pull/22923#pullrequestreview-3924527851) - 2026-03-10
+* [Review] [Review on: perf(provider): drop clones before to_plain_state_reverts](https://github.com/paradigmxyz/reth/pull/22918#pullrequestreview-3923631738) - 2026-03-10
+* [Review] [Review on: feat(cli): make storage v2 default for new nodes](https://github.com/paradigmxyz/reth/pull/22890#pullrequestreview-3923447059) - 2026-03-10
+* [Review] [Review on: chore: bump reth v1.11.2](https://github.com/paradigmxyz/reth/pull/22914#pullrequestreview-3922575939) - 2026-03-10
+* [Review] [Review on: perf(engine): offload DeferredDrops deallocation to a persistent background thread](https://github.com/paradigmxyz/reth/pull/22908#pullrequestreview-3921551083) - 2026-03-10
+* [Review] [Review on: perf(engine): offload DeferredDrops deallocation to a persistent background thread](https://github.com/paradigmxyz/reth/pull/22908#pullrequestreview-3921558050) - 2026-03-10
+* [Review] [Review on: perf(engine): offload DeferredDrops deallocation to a persistent background thread](https://github.com/paradigmxyz/reth/pull/22908#pullrequestreview-3921898635) - 2026-03-10
+* [Review] [Review on: fix(bench): retry HTTP 502 errors in block provider](https://github.com/paradigmxyz/reth/pull/22916#pullrequestreview-3922049763) - 2026-03-10
+* [Review] [Review on: refactor(engine): remove unused MultiProofMessage::EmptyProof variant](https://github.com/paradigmxyz/reth/pull/22909#pullrequestreview-3920895969) - 2026-03-10
+* [Review] [Review on: revert: use line-tables-only debug info for profiling profile](https://github.com/paradigmxyz/reth/pull/22907#pullrequestreview-3920902258) - 2026-03-10
 [bluealloy/revm](https://github.com/bluealloy/revm)
 * [Pull Request] [perf: elide some jumps in jump](https://github.com/bluealloy/revm/pull/3347) - 2026-01-23
 * [Pull Request] []() - 2026-01-25

--- a/members/dapplion.md
+++ b/members/dapplion.md
@@ -15,33 +15,33 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Adapp
 * [Issue] [ePBS side-effects on Lighthouse](https://github.com/sigp/lighthouse/issues/8630) - 2026-01-07
 * [Issue] [Gloas ePBS breaks dependant root?](https://github.com/sigp/lighthouse/issues/8629) - 2026-01-07
 * [Issue] [Static File Backend for Lighthouse Cold DB](https://github.com/sigp/lighthouse/issues/8634) - 2026-01-08
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [Remove merge transition code](https://github.com/sigp/lighthouse/pull/8761) - 2026-02-05
+* [Pull Request] [rename --reconstruct-historic-states to --archive](https://github.com/sigp/lighthouse/pull/8795) - 2026-02-10
 * [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [Add ai agent safety tooling](https://github.com/sigp/lighthouse/pull/8898) - 2026-02-24
 
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952) - 2026-03-09
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-08
+* [Pull Request] [Extend by_root reqresp serve range to match by_range](https://github.com/ethereum/consensus-specs/pull/4950) - 2026-02-26
+* [Pull Request] [Typo sorry](https://github.com/ethereum/consensus-specs/pull/4989) - 2026-03-08
 ## Q4 2025
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2025-10-25
+* [Pull Request] [Prevent dropping large binary data to logs](https://github.com/sigp/lighthouse/pull/8290) - 2025-10-25
 * [Issue] [Slow head sync in tinny devnet](https://github.com/sigp/lighthouse/issues/8289) - 2025-10-25
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [Match BlockError into penalty in block gossip](https://github.com/sigp/lighthouse/pull/8301) - 2025-10-27
 * [Issue] [Remove lighthouse_version dependency on everything but top level lighthouse](https://github.com/sigp/lighthouse/issues/8328) - 2025-10-29
 * [Issue] [Fork-choice clean-up / simplification](https://github.com/sigp/lighthouse/issues/8325) - 2025-10-29
-* [Pull Request] []() - 2025-11-07
+* [Pull Request] [Safe non-finalized checkpoint sync](https://github.com/sigp/lighthouse/pull/8382) - 2025-11-07
 
-* [Pull Request] []() - 2025-11-15
-* [Pull Request] []() - 2025-12-16
+* [Pull Request] [Reimport the checkpoint sync block](https://github.com/sigp/lighthouse/pull/8417) - 2025-11-15
+* [Pull Request] [Tree-sync friendly lookup sync tests](https://github.com/sigp/lighthouse/pull/8592) - 2025-12-16
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-11-10
+* [Pull Request] [Suggest to queue DataColumnSidecars if they race the block](https://github.com/ethereum/consensus-specs/pull/4736) - 2025-11-10
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
-* [Pull Request] []() - 2025-12-03
+* [Pull Request] [test: remove testcontainers dependency for web3signer test](https://github.com/ChainSafe/lodestar/pull/4567) - 2025-12-03
 ## Q3 2025
 
 

--- a/members/dapplion.md
+++ b/members/dapplion.md
@@ -21,6 +21,15 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Adapp
 * [Pull Request] [Add ai agent safety tooling](https://github.com/sigp/lighthouse/pull/8898) - 2026-02-24
 
 * [Pull Request] [Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952) - 2026-03-09
+* [Review] [Review on: Schedule Fulu fork for Chiado testnet](https://github.com/sigp/lighthouse/pull/8954#pullrequestreview-3924753414) - 2026-03-10
+* [Review] [Review on: Update contribution guidlines regarding LLM usage](https://github.com/sigp/lighthouse/pull/8879#pullrequestreview-3924063859) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923993165) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923994094) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923995904) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923996802) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923997668) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923998477) - 2026-03-10
+* [Review] [Review on: Fast Confirmation Rule - BUT optional and doesn't touch production code :)](https://github.com/sigp/lighthouse/pull/8951#pullrequestreview-3923999241) - 2026-03-10
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Pull Request] [Extend by_root reqresp serve range to match by_range](https://github.com/ethereum/consensus-specs/pull/4950) - 2026-02-26
 * [Pull Request] [Typo sorry](https://github.com/ethereum/consensus-specs/pull/4989) - 2026-03-08

--- a/members/domiwei.md
+++ b/members/domiwei.md
@@ -21,7 +21,7 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [beacon state](https://github.com/erigontech/erigon/issues/18563) - 2026-01-06
 * [Issue] [beacon api](https://github.com/erigontech/erigon/issues/19089) - 2026-02-10
 * [Issue] [persist new block format](https://github.com/erigontech/erigon/issues/19351) - 2026-02-20
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [fix missing attestations by using GossipSub for subnet peer coverage](https://github.com/erigontech/erigon/pull/19523) - 2026-02-28
 ## Q3 2025
 
 

--- a/members/ensi321.md
+++ b/members/ensi321.md
@@ -12,27 +12,30 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-22
+* [Pull Request] [Add test for execution payload with wrong withdrawals](https://github.com/ethereum/consensus-specs/pull/4856) - 2026-01-22
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
 * [Issue] [Implement queue for execution payload in Gloas](https://github.com/ChainSafe/lodestar/issues/8811) - 2026-01-30
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [feat: add gloas block import pipeline](https://github.com/ChainSafe/lodestar/pull/8940) - 2026-02-25
+* [Pull Request] [feat: add gloas execution payload envelope import pipeline](https://github.com/ChainSafe/lodestar/pull/8962) - 2026-02-26
+* [Pull Request] [feat: implement epbs fork choice](https://github.com/ChainSafe/lodestar/pull/8739) - 2026-03-04
+* [Pull Request] [fix: payload status on fork chocie init](https://github.com/ChainSafe/lodestar/pull/8987) - 2026-03-05
+
+[ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
+* [Pull Request] [refactor: clone state in processExecutionPayloadEnvelope](https://github.com/ChainSafe/lodestar/pull/9015) - 2026-03-10
 ## Q4 2025
 
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
 * [Commit] [Draft 2](https://github.com/ChainSafe/lodestar/commit/4e568ce30988d36e4726b0c569ec2f6dc3f31d3a) - 2025-10-03
 * [Commit] [fix: return spec constants starting with 0x as hex strings instead of decimal (#8495)](https://github.com/ChainSafe/lodestar/commit/894daf8b4487e6c35337a87abaef1f372b5193c6) - 2025-10-06
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [chore: migrate to `consensus-specs` for spec tests](https://github.com/ChainSafe/lodestar/pull/8591) - 2025-10-30
+* [Pull Request] [feat: enable gloas spec tests](https://github.com/ChainSafe/lodestar/pull/8609) - 2025-11-05
 
-* [Pull Request] []() - 2025-11-17
+* [Pull Request] [feat: implement ePBS gossip topics](https://github.com/ChainSafe/lodestar/pull/8616) - 2025-11-17
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-11-11
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [Clean up Gloas specs (part 5)](https://github.com/ethereum/consensus-specs/pull/4738) - 2025-11-11
+* [Pull Request] [Refactor `get_weight` and `is_supporting_vote`](https://github.com/ethereum/consensus-specs/pull/4800) - 2025-12-19
 ## Q3 2025
 
 

--- a/members/ericsson49.md
+++ b/members/ericsson49.md
@@ -17,8 +17,8 @@ Relevant work: [hackMD](https://hackmd.io/@ericsson49), [ethresearch](https://et
 
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-10-17
+* [Pull Request] [Use `specConfig.getBLSSignatureVerifier()` instead of `BLSSignatureVerifier.SIMPLE`](https://github.com/Consensys/teku/pull/10016) - 2025-10-15
+* [Pull Request] [Fork choice compliance test integration](https://github.com/Consensys/teku/pull/10031) - 2025-10-17
 ## Q3 2025
 
 

--- a/members/eserilev.md
+++ b/members/eserilev.md
@@ -15,24 +15,25 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aeser
 * [Issue] [Move some DA checker functionality to `CustodyContext`](https://github.com/sigp/lighthouse/issues/8633) - 2026-01-07
 * [Pull Request] []() - 2026-01-11
 * [Issue] [Flag to disable "unsafe" range sync](https://github.com/sigp/lighthouse/issues/8657) - 2026-01-13
-* [Pull Request] []() - 2026-01-14
-* [Pull Request] []() - 2026-01-18
+* [Pull Request] [And CPU bound and IO bound worker categories to the Beacon Processor](https://github.com/sigp/lighthouse/pull/8661) - 2026-01-14
+* [Pull Request] [Gloas Column and Blob variants and deprecating full blob support](https://github.com/sigp/lighthouse/pull/8674) - 2026-01-18
 * [Issue] [Update all gloas slot timing logic to use the correct slot component config values](https://github.com/sigp/lighthouse/issues/8686) - 2026-01-20
-* [Pull Request] []() - 2026-01-20
+* [Pull Request] [Add Gloas data column support ](https://github.com/sigp/lighthouse/pull/8682) - 2026-01-20
 
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-01-30
+* [Pull Request] [Move DA boundary checks to CustodyContext](https://github.com/sigp/lighthouse/pull/8696) - 2026-01-22
+* [Pull Request] [Gloas attestation verification ](https://github.com/sigp/lighthouse/pull/8705) - 2026-01-27
+* [Pull Request] [Payload envelope db operations](https://github.com/sigp/lighthouse/pull/8717) - 2026-01-29
+* [Pull Request] [Move KZG commitments from payload envelope to payload bid and spec alpha.2](https://github.com/sigp/lighthouse/pull/8725) - 2026-01-30
 * [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-14
+* [Pull Request] [Gloas devnet 0](https://github.com/sigp/lighthouse/pull/8821) - 2026-02-14
 * [Issue] [Gloas issues with SSE event `ExtendedPayloadAttributes`](https://github.com/sigp/lighthouse/issues/8817) - 2026-02-14
 * [Issue] [Gloas stateless/stateful block production endpoints](https://github.com/sigp/lighthouse/issues/8828) - 2026-02-16
 * [Issue] [Error requesting finalized Gloas state](https://github.com/sigp/lighthouse/issues/8869) - 2026-02-19
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [Update contribution guidlines regarding LLM usage](https://github.com/sigp/lighthouse/pull/8879) - 2026-02-20
 * [Issue] [Implement blinded payloads for `ExecutionPayloadEnvelope`](https://github.com/sigp/lighthouse/issues/8888) - 2026-02-23
+* [Pull Request] [Update contribution guidlines regarding LLM usage](https://github.com/sigp/lighthouse/pull/8879) - 2026-03-10
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Add details about how a validator should set `blob_data_available` for `PayloadAttestationData`](https://github.com/ethereum/consensus-specs/pull/4854) - 2026-01-21
 ## Q4 2025
 
 
@@ -40,16 +41,16 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aeser
 * [Pull Request] [Automatically pass spans into blocking handles](https://github.com/sigp/lighthouse/pull/8158) - 2025-10-02
 * [Pull Request] [Ensure status v2 returns the earliest available block when custody requirements are satisified for the da retention period](https://github.com/sigp/lighthouse/pull/8177) - 2025-10-09
 * [Issue] [Remove `BlobInfo`](https://github.com/sigp/lighthouse/issues/8203) - 2025-10-14
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-20
+* [Pull Request] [Remove `DataColumnInfo`](https://github.com/sigp/lighthouse/pull/8202) - 2025-10-14
+* [Pull Request] [Fix data column rpc request](https://github.com/sigp/lighthouse/pull/8247) - 2025-10-20
 * [Issue] [Custody backfill sync shows incorrect estimated time to completion](https://github.com/sigp/lighthouse/issues/8268) - 2025-10-22
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-11-02
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-11-17
-* [Pull Request] []() - 2025-11-22
+* [Pull Request] [Rust 1.91 lints](https://github.com/sigp/lighthouse/pull/8340) - 2025-10-30
+* [Pull Request] [Add mainnet configs](https://github.com/sigp/lighthouse/pull/8344) - 2025-11-02
+* [Pull Request] [Make RPC block always available](https://github.com/sigp/lighthouse/pull/8411) - 2025-11-13
+* [Pull Request] [Convert RpcBlock to an enum that indicates availability](https://github.com/sigp/lighthouse/pull/8424) - 2025-11-17
+* [Pull Request] [Enable multi node attestation consensus for the VC](https://github.com/sigp/lighthouse/pull/8445) - 2025-11-22
 * [Issue] [Set trace sampling as the default behavior](https://github.com/sigp/lighthouse/issues/8554) - 2025-12-08
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [Rust 1.92 lints](https://github.com/sigp/lighthouse/pull/8567) - 2025-12-11
 * [Pull Request] []() - 2025-12-12
 ## Q3 2025
 

--- a/members/eserilev.md
+++ b/members/eserilev.md
@@ -31,6 +31,7 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aeser
 * [Issue] [Error requesting finalized Gloas state](https://github.com/sigp/lighthouse/issues/8869) - 2026-02-19
 * [Pull Request] []() - 2026-02-20
 * [Issue] [Implement blinded payloads for `ExecutionPayloadEnvelope`](https://github.com/sigp/lighthouse/issues/8888) - 2026-02-23
+* [Pull Request] []() - 2026-03-10
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Pull Request] []() - 2026-01-21
 ## Q4 2025

--- a/members/etan-status.md
+++ b/members/etan-status.md
@@ -12,20 +12,20 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [Merkleize progressive SSZ shape to right](https://github.com/ethereum/consensus-specs/pull/4813) - 2026-01-06
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [Update EIP-7799: Add fee payment log](https://github.com/ethereum/EIPs/pull/11091) - 2026-01-15
 
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Add on_slot_start_after_past_attestations_applied hook](https://github.com/status-im/nimbus-eth2/pull/7929) - 2026-02-04
+* [Pull Request] [Update MAX_EFFECTIVE_BALANCE_ELECTRA to uint64](https://github.com/status-im/nimbus-eth2/pull/7943) - 2026-02-06
+* [Pull Request] [Track slashed validators in EpochRef](https://github.com/status-im/nimbus-eth2/pull/7944) - 2026-02-07
+* [Pull Request] [Re-enable progressive shape SSZ tests](https://github.com/status-im/nimbus-eth2/pull/7856) - 2026-02-10
+* [Pull Request] [Track slot assignments for current / previous epoch in fork choice](https://github.com/status-im/nimbus-eth2/pull/7985) - 2026-02-16
+* [Pull Request] [Track support from empty slots and from equivocating validators for FCR](https://github.com/status-im/nimbus-eth2/pull/8026) - 2026-02-24
+* [Pull Request] [Add get_current_target_score implementation for fast confirmation rule](https://github.com/status-im/nimbus-eth2/pull/8031) - 2026-03-03
+* [Pull Request] [Use [] on balances/validators instead of item](https://github.com/status-im/nimbus-eth2/pull/8014) - 2026-03-06
 ## Q4 2025
 
 
@@ -46,18 +46,18 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Pull Request] [Bump nim-stew](https://github.com/status-im/nimbus-eth2/pull/7589) - 2025-10-09
 
 * [Pull Request] [Run fork_choice and proto_array tests](https://github.com/status-im/nimbus-eth2/pull/7607) - 2025-10-13
-* [Pull Request] []() - 2025-11-01
-* [Pull Request] []() - 2025-11-16
+* [Pull Request] [Apply policy: Retain back through Mainnet's second latest fork](https://github.com/status-im/nimbus-eth2/pull/7701) - 2025-11-01
+* [Pull Request] [Add option to light client to sync finality to engine API](https://github.com/status-im/nimbus-eth2/pull/7735) - 2025-11-16
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Update EIP-7916: Move to Review](https://github.com/ethereum/EIPs/pull/10526) - 2025-10-12
 
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [Add EIP: Replace cumulative receipt fields](https://github.com/ethereum/EIPs/pull/10998) - 2025-12-30
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-10-16
-* [Pull Request] []() - 2025-11-04
+* [Pull Request] [Reduce SSZ test vector size](https://github.com/ethereum/consensus-specs/pull/4662) - 2025-10-16
+* [Pull Request] [Use proper integer encoding for Union in SSZ](https://github.com/ethereum/consensus-specs/pull/4725) - 2025-11-04
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2025-11-19
+* [Pull Request] [Add NimMain export to verifproxy library](https://github.com/status-im/nimbus-eth1/pull/3835) - 2025-11-19
 ## Q3 2025
 
 

--- a/members/ethdreamer.md
+++ b/members/ethdreamer.md
@@ -12,7 +12,7 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3AethD
 
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-10-24
+* [Pull Request] [eip7732: add gossip rule for old payloads](https://github.com/ethereum/consensus-specs/pull/4695) - 2025-10-24
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
 * [Issue] [Gloas Range Sync Modifications](https://github.com/sigp/lighthouse/issues/8341) - 2025-10-30

--- a/members/fab-10.md
+++ b/members/fab-10.md
@@ -12,19 +12,19 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Afa
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-20
+* [Pull Request] [Pass block creation candidate transaction list to plugins](https://github.com/besu-eth/besu/pull/9627) - 2026-01-12
+* [Pull Request] [Enhance payload selection with tx count and creation time tiebreakers](https://github.com/besu-eth/besu/pull/9657) - 2026-01-20
 * [Issue] [EIP-7975: eth/70 - partial block receipt lists](https://github.com/hyperledger/besu/issues/9665) - 2026-01-21
-* [Pull Request] []() - 2026-01-23
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [Periodical log internal stats of PeerTransactionTraker is TRACE log is enabled](https://github.com/besu-eth/besu/pull/9680) - 2026-01-23
+* [Pull Request] [Backport: Execute pre-processors before tracing transactions](https://github.com/besu-eth/besu/pull/9697) - 2026-01-27
+* [Pull Request] [Remove unused `GetReceiptsFromPeerTask` code](https://github.com/besu-eth/besu/pull/9780) - 2026-02-10
+* [Pull Request] [Cleanup, refactor and add trace logs to DownloadSyncReceiptsStep](https://github.com/besu-eth/besu/pull/9802) - 2026-02-13
 * [Issue] [Prevent running Clique networks not migrated to PoS](https://github.com/hyperledger/besu/issues/9884) - 2026-02-24
 * [Issue] [Removal of Clique consensus support](https://github.com/hyperledger/besu/issues/9883) - 2026-02-24
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [Implement EIP-7975: eth/70 - partial block receipt lists](https://github.com/besu-eth/besu/pull/9910) - 2026-02-26
 * [Issue] [Review blockchain sync request sizing](https://github.com/hyperledger/besu/issues/9908) - 2026-02-26
-* [Pull Request] []() - 2026-03-06
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Remove Clique RPC APIs and management infrastructure (Phase 2)](https://github.com/besu-eth/besu/pull/9992) - 2026-03-06
+* [Pull Request] [Implement `txpool_status` RPC method](https://github.com/besu-eth/besu/pull/10002) - 2026-03-09
 ## Q4 2025
 
 
@@ -33,15 +33,15 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Afa
 * [Commit] [Refactor: uniform the way genesis config options are passed to protocol specs (#9279)](https://github.com/hyperledger/besu/commit/226b133cf957015180b809a7da2cfc0e29574345) - 2025-10-08
 * [Pull Request] [WIP](https://github.com/hyperledger/besu/pull/9285) - 2025-10-09
 * [Commit] [Add `isCancelled` method to `TransactionEvaluationContext` (#9285)](https://github.com/hyperledger/besu/commit/84668d4c71b5f9c6bff7f052f6071dcbce94d353) - 2025-10-10
-* [Pull Request] []() - 2025-10-22
-* [Pull Request] []() - 2025-10-24
-* [Pull Request] []() - 2025-11-06
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-12-01
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [Tune start script for OpenJDK 25 and use it in Docker image](https://github.com/besu-eth/besu/pull/9346) - 2025-10-22
+* [Pull Request] [CI: optimize pre-review workflow](https://github.com/besu-eth/besu/pull/9363) - 2025-10-24
+* [Pull Request] [Transaction broadcast remove support for pre eth/65 peers](https://github.com/besu-eth/besu/pull/9405) - 2025-11-06
+* [Pull Request] [Make the max size of a transactions p2p message configurable](https://github.com/besu-eth/besu/pull/9424) - 2025-11-12
+* [Pull Request] [Add extensive trace logging for transaction p2p broadcast](https://github.com/besu-eth/besu/pull/9433) - 2025-11-13
+* [Pull Request] [Fix: MiningConfiguration object must not be re-created](https://github.com/besu-eth/besu/pull/9518) - 2025-12-01
+* [Pull Request] [Improve output of plugin versions](https://github.com/besu-eth/besu/pull/9534) - 2025-12-05
+* [Pull Request] [Allow to reload configuration for all plugins with a single call](https://github.com/besu-eth/besu/pull/9563) - 2025-12-11
+* [Pull Request] [Move test plugins in a detached project so they can use the Gradle Besu plugin](https://github.com/besu-eth/besu/pull/9590) - 2025-12-19
 ## Q3 2025
 
 

--- a/members/fab-10.md
+++ b/members/fab-10.md
@@ -25,6 +25,9 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Afa
 * [Issue] [Review blockchain sync request sizing](https://github.com/hyperledger/besu/issues/9908) - 2026-02-26
 * [Pull Request] [Remove Clique RPC APIs and management infrastructure (Phase 2)](https://github.com/besu-eth/besu/pull/9992) - 2026-03-06
 * [Pull Request] [Implement `txpool_status` RPC method](https://github.com/besu-eth/besu/pull/10002) - 2026-03-09
+* [Review] [Review on: Implement `txpool_status` RPC method](https://github.com/besu-eth/besu/pull/10002#pullrequestreview-3923770897) - 2026-03-10
+* [Review] [Review on: Implement `txpool_status` RPC method](https://github.com/besu-eth/besu/pull/10002#pullrequestreview-3923775813) - 2026-03-10
+* [Review] [Review on: Implement `txpool_status` RPC method](https://github.com/besu-eth/besu/pull/10002#pullrequestreview-3923817785) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/felix314159.md
+++ b/members/felix314159.md
@@ -10,7 +10,7 @@ Github: [@felix314159](https://github.com/felix314159)
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-30
+* [Pull Request] [core: fix initialization of `parallelProcessor`](https://github.com/ethereum/go-ethereum/pull/33723) - 2026-01-30
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Issue] [static_test(port): EIP-196 test cases coverage](https://github.com/ethereum/execution-specs/issues/2421) - 2026-03-05
+* [Issue] [static_test(port): EIP-196 test cases coverage](https://github.com/ethereum/execution-specs/issues/2421) - 2026-03-05* [Pull Request] [feat(t8n): handle pre-fork typed txs via `supports_tx_type`](https://github.com/ethereum/execution-specs/pull/2466) - 2026-03-10

--- a/members/fgimenez.md
+++ b/members/fgimenez.md
@@ -34,7 +34,7 @@ Team: [Reth](https://github.com/paradigmxyz/reth/commits?author=fgimenez)
 * [Commit] [fix patch](https://github.com/paradigmxyz/reth/commit/095d93457e866b8d86c77cedb9a07a25deead3f3) - 2025-10-10
 * [Pull Request] [chore(ci): update eest 7594 issue link in hive expected failures file](https://github.com/paradigmxyz/reth/pull/18976) - 2025-10-13
 * [Issue] [Fix eest eip7594_peerdas/test_max_blob_per_tx](https://github.com/paradigmxyz/reth/issues/18975) - 2025-10-13
-* [Pull Request] []() - 2025-10-20
+* [Pull Request] [feat(e2e): add builder API for configuring test node setups](https://github.com/paradigmxyz/reth/pull/19146) - 2025-10-20
 * [Issue] [Add example for custom chain hardforks](https://github.com/paradigmxyz/reth/issues/19285) - 2025-10-24
 * [Issue] [Add CLI flags to enable RocksDB storage](https://github.com/paradigmxyz/reth/issues/20393) - 2025-12-15
 * [Issue] [Initialize RocksDB provider and add consistency check on startup](https://github.com/paradigmxyz/reth/issues/20392) - 2025-12-15
@@ -46,7 +46,7 @@ Team: [Reth](https://github.com/paradigmxyz/reth/commits?author=fgimenez)
 * [Issue] [Register column families at RocksDB initialization](https://github.com/paradigmxyz/reth/issues/20386) - 2025-12-15
 * [Issue] [Wire up RocksDB for TransactionHashNumbers and StoragesHistory tables](https://github.com/paradigmxyz/reth/issues/20384) - 2025-12-15
 * [Issue] [Create E2E test to verify RocksDB provider functionality](https://github.com/paradigmxyz/reth/issues/20424) - 2025-12-16
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [feat(stages): use EitherWriter for TransactionLookupStage RocksDB writes](https://github.com/paradigmxyz/reth/pull/20428) - 2025-12-18
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] [Federico Gimenez 1 -> 0.5](https://github.com/protocolguild/documentation/pull/430) - 2025-10-04
 
@@ -54,7 +54,7 @@ Team: [Reth](https://github.com/paradigmxyz/reth/commits?author=fgimenez)
 * [Issue] [Flaky "Invalid Missing Ancestor Syncing ReOrg" tests fail when payload contains no transactions](https://github.com/ethereum/hive/issues/1351) - 2025-10-07
 
 [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests)
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [chore(cli): update max fee per blob gas limit for reth exception mapper](https://github.com/ethereum/execution-spec-tests/pull/2300) - 2025-10-15
 ## Q3 2025
 
 

--- a/members/flcl42.md
+++ b/members/flcl42.md
@@ -12,7 +12,11 @@ Team: [NethermindEth contributions](https://github.com/flcl42?org=NethermindEth)
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-02-16
+* [Pull Request] [✨ feat(EIP-7708): Burn logs](https://github.com/NethermindEth/nethermind/pull/10544) - 2026-02-16
+
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Pull Request] [Reset GasUsed when simulating txs](https://github.com/NethermindEth/nethermind/pull/10766) - 2026-03-10
+* [Commit] [Reset GasUsed when simulating txs (#10766)](https://github.com/NethermindEth/nethermind/commit/24747b5a1c4c2946930feb697c3031fe49007727) - 2026-03-10
 ## Q4 2025
 
 
@@ -38,14 +42,14 @@ Team: [NethermindEth contributions](https://github.com/flcl42?org=NethermindEth)
 * [Commit] [XDC : QuorumCertificate Manager (#9294)](https://github.com/NethermindEth/nethermind/commit/a86580138981169298b8ab15338569dcfea96543) - 2025-10-08
 * [Commit] [Remove quick fail when running Hive tests (#9426)](https://github.com/NethermindEth/nethermind/commit/8cea3fc2f2deb3696d9c4dbe7e14c6ebe912f424) - 2025-10-08
 
-* [Pull Request] []() - 2025-11-05
-* [Pull Request] []() - 2025-12-23
-* [Pull Request] []() - 2025-12-25
+* [Pull Request] [State related suggestions](https://github.com/NethermindEth/nethermind/pull/9651) - 2025-11-05
+* [Pull Request] [Validate blobs lengths](https://github.com/NethermindEth/nethermind/pull/9999) - 2025-12-23
+* [Pull Request] [Update schema](https://github.com/NethermindEth/nethermind/pull/10035) - 2025-12-25
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [cmd/devp2p/internal/ethtest: cover acceptable differences in communication](https://github.com/ethereum/go-ethereum/pull/33031) - 2025-10-27
 
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2025-11-20
+* [Pull Request] [Change transaction type for gas estimation test](https://github.com/ethereum/execution-apis/pull/709) - 2025-11-20
 ## Q3 2025
 
 

--- a/members/flcl42.md
+++ b/members/flcl42.md
@@ -17,6 +17,11 @@ Team: [NethermindEth contributions](https://github.com/flcl42?org=NethermindEth)
 [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
 * [Pull Request] [Reset GasUsed when simulating txs](https://github.com/NethermindEth/nethermind/pull/10766) - 2026-03-10
 * [Commit] [Reset GasUsed when simulating txs (#10766)](https://github.com/NethermindEth/nethermind/commit/24747b5a1c4c2946930feb697c3031fe49007727) - 2026-03-10
+* [Review] [Review on: Fix event handler leaks, reduce allocations, and refactor Network layer](https://github.com/NethermindEth/nethermind/pull/10753#pullrequestreview-3923780248) - 2026-03-10
+* [Review] [Review on: fix: Add new RLP decoders for zkEVM](https://github.com/NethermindEth/nethermind/pull/10773#pullrequestreview-3924559639) - 2026-03-10
+* [Review] [Review on: Fix rare `IndexOutOfRangeException` in `eth_getLogs` when block data is missing](https://github.com/NethermindEth/nethermind/pull/10771#pullrequestreview-3924160422) - 2026-03-10
+* [Review] [Review on: Enforce GasCap across debug and trace RPC methods](https://github.com/NethermindEth/nethermind/pull/10457#pullrequestreview-3923273548) - 2026-03-10
+* [Review] [Review on: feat(jsonrpc): add eth_subscribe transactionReceipts subscription](https://github.com/NethermindEth/nethermind/pull/10524#pullrequestreview-3921530800) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/fradamt.md
+++ b/members/fradamt.md
@@ -12,14 +12,14 @@ Team: Consensus R&D (EF)
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-28
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-11-14
-* [Pull Request] []() - 2025-11-20
+* [Pull Request] [Update EIP-7773: Propose EIP-8061 for Glamsterdam](https://github.com/ethereum/EIPs/pull/10643) - 2025-10-28
+* [Pull Request] [Update EIP-8061: bring back deposit cap and let exits use the consolidation queue](https://github.com/ethereum/EIPs/pull/10765) - 2025-11-10
+* [Pull Request] [Add EIP: Let exits use the consolidation queue](https://github.com/ethereum/EIPs/pull/10790) - 2025-11-13
+* [Pull Request] [Update EIP-7773: PFI 8080](https://github.com/ethereum/EIPs/pull/10796) - 2025-11-14
+* [Pull Request] [Update EIP-7594: minor fix](https://github.com/ethereum/EIPs/pull/10815) - 2025-11-20
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [Finishing touches for the gloas fork-choice](https://github.com/ethereum/consensus-specs/pull/4807) - 2025-12-30
 ## Q3 2025
 
 

--- a/members/fselmo.md
+++ b/members/fselmo.md
@@ -12,28 +12,28 @@ Team: [STEEL](https://github.com/ethereum/execution-spec-tests)
 
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2026-01-05
+* [Pull Request] [fix(test): Increase balance for blob test fails w/ larger blob params](https://github.com/ethereum/execution-specs/pull/1975) - 2026-01-05
 * [Issue] [Make EIP-7934 tests fork agnostic](https://github.com/ethereum/execution-specs/issues/1972) - 2026-01-05
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-09
+* [Pull Request] [chore(test-types): Add `extra="forbid"` to `CamelModel`; fix errors](https://github.com/ethereum/execution-specs/pull/1989) - 2026-01-07
+* [Pull Request] [fix(test-types): Loosen pydantic strictness on internal pydantic models](https://github.com/ethereum/execution-specs/pull/2000) - 2026-01-09
 * [Issue] [Consider refactoring `Frontier(BaseFork)`  into scoped mixins](https://github.com/ethereum/execution-specs/issues/2025) - 2026-01-15
 * [Issue] [Increase RAM on pypy3 CI self-hosted runner](https://github.com/ethereum/execution-specs/issues/2029) - 2026-01-15
 
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [feat(spec,test): EIP-7708 spec updates for self as target](https://github.com/ethereum/execution-specs/pull/2086) - 2026-01-27
+* [Pull Request] [feat(test): update EIP-8024 refspec and align on latest changes to EIP](https://github.com/ethereum/execution-specs/pull/2095) - 2026-01-28
+* [Pull Request] [feat(test-fill): speed up filling](https://github.com/ethereum/execution-specs/pull/2079) - 2026-01-29
+* [Pull Request] [fix(test,benchmark): cap data tests to rlp block limit](https://github.com/ethereum/execution-specs/pull/2110) - 2026-01-31
+* [Pull Request] [fix(test-consume): Add hive ruleset for `BPO2ToAmsterdamAtTime15k`](https://github.com/ethereum/execution-specs/pull/2111) - 2026-02-01
+* [Pull Request] [fix(test-fill): improve memory buildup for fill; merge on `SIGINT` / `SIGTERM`](https://github.com/ethereum/execution-specs/pull/2117) - 2026-02-02
+* [Pull Request] [feat(test-fill): performance improvements for release processes and fill](https://github.com/ethereum/execution-specs/pull/2140) - 2026-02-04
+* [Pull Request] [fix(test-ci): fix issues with recent changes to checklist](https://github.com/ethereum/execution-specs/pull/2151) - 2026-02-05
+* [Pull Request] [feat(test): performance and fill updates; print -> debug log session finish](https://github.com/ethereum/execution-specs/pull/2150) - 2026-02-09
 * [Issue] [Align on `Opcode`and `Bytecode` `__hash__` and `__eq__` logic](https://github.com/ethereum/execution-specs/issues/2190) - 2026-02-11
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [chore(test): Remove duplicate test](https://github.com/ethereum/execution-specs/pull/2210) - 2026-02-13
 * [Issue] [Support inequality validation for `post` in tests](https://github.com/ethereum/execution-specs/issues/2227) - 2026-02-18
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2026-01-15
-* [Pull Request] []() - 2026-02-03
+* [Pull Request] [fix: update BPO defaults](https://github.com/ethereum/hive/pull/1380) - 2026-01-15
+* [Pull Request] [fix: remove Amsterdam defaults (named fork in blob params)](https://github.com/ethereum/hive/pull/1387) - 2026-02-03
 * [Pull Request] []() - 2026-02-12
 ## Q4 2025
 
@@ -71,17 +71,17 @@ Team: [STEEL](https://github.com/ethereum/execution-spec-tests)
 * [Issue] [chore(types): Tighten validation on `Block` modifiers](https://github.com/ethereum/execution-specs/issues/1626) - 2025-10-16
 * [Issue] [Add `extra_forbid` to `CamelModel` and fix errors](https://github.com/ethereum/execution-specs/issues/1612) - 2025-10-16
 
-* [Pull Request] []() - 2025-11-03
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [fix(spec-specs): Fix early issues from bals release v1.4.0](https://github.com/ethereum/execution-specs/pull/1743) - 2025-11-03
+* [Pull Request] [refactor(spec-specs): Refactor state changes and frame hierarchy](https://github.com/ethereum/execution-specs/pull/1841) - 2025-12-03
+* [Pull Request] [feat(test-tests): Expand BAL CALL opcode OOG boundary test cases](https://github.com/ethereum/execution-specs/pull/1882) - 2025-12-10
+* [Pull Request] [refactor(spec-specs): Refactor specs to be more coherent wrt gas acco…](https://github.com/ethereum/execution-specs/pull/1897) - 2025-12-11
+* [Pull Request] [fix(test): align blob params with specs for Amsterdam](https://github.com/ethereum/execution-specs/pull/1926) - 2025-12-16
+* [Pull Request] [feat(spec-tests): update json infra test version](https://github.com/ethereum/execution-specs/pull/1939) - 2025-12-17
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-10-21
+* [Pull Request] [fix: Nethermind not connecting via `HIVE_BOOTNODE` for sync tests](https://github.com/ethereum/hive/pull/1360) - 2025-10-21
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [Update EIP-7907: Minor clarifications for readability](https://github.com/ethereum/EIPs/pull/10992) - 2025-12-30
 ## Q3 2025
 
 [ethereum/hive](https://github.com/ethereum/hive)

--- a/members/fselmo.md
+++ b/members/fselmo.md
@@ -31,6 +31,7 @@ Team: [STEEL](https://github.com/ethereum/execution-spec-tests)
 * [Issue] [Align on `Opcode`and `Bytecode` `__hash__` and `__eq__` logic](https://github.com/ethereum/execution-specs/issues/2190) - 2026-02-11
 * [Pull Request] [chore(test): Remove duplicate test](https://github.com/ethereum/execution-specs/pull/2210) - 2026-02-13
 * [Issue] [Support inequality validation for `post` in tests](https://github.com/ethereum/execution-specs/issues/2227) - 2026-02-18
+* [Review] [Review on: refactor(test-forks): Remove `block_number`/`timestamp` from all methods](https://github.com/ethereum/execution-specs/pull/2442#pullrequestreview-3926056928) - 2026-03-10
 [ethereum/hive](https://github.com/ethereum/hive)
 * [Pull Request] [fix: update BPO defaults](https://github.com/ethereum/hive/pull/1380) - 2026-01-15
 * [Pull Request] [fix: remove Amsterdam defaults (named fork in blob params)](https://github.com/ethereum/hive/pull/1387) - 2026-02-03

--- a/members/gabriel-trintinalia.md
+++ b/members/gabriel-trintinalia.md
@@ -12,9 +12,9 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AGa
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [refactor: decouple peer discovery agent](https://github.com/besu-eth/besu/pull/9607) - 2026-01-07
+* [Pull Request] [feat: skip peers without listening port](https://github.com/besu-eth/besu/pull/9628) - 2026-01-12
+* [Pull Request] [feat: remove compression from engine responses](https://github.com/besu-eth/besu/pull/9667) - 2026-01-21
 * [Issue] [Make Discovery CLI Options Explicitly DiscV4-Specific](https://github.com/hyperledger/besu/issues/9694) - 2026-01-27
 * [Issue] [Fine-Tune Discovery v5 Parameters and Make Them Configurable](https://github.com/hyperledger/besu/issues/9693) - 2026-01-27
 * [Issue] [Add Metrics for Discovery v5](https://github.com/hyperledger/besu/issues/9692) - 2026-01-27
@@ -37,16 +37,16 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AGa
 * [Commit] [Add Osaka Engine acceptance test (#9268)](https://github.com/hyperledger/besu/commit/5051cc1eeff9d41d82bd2d5bf1be09efcee09803) - 2025-10-03
 * [Commit] [chore: bpo cleanup (#9286)](https://github.com/hyperledger/besu/commit/14b103e0475086f4ae639c31c2c027c2ae0ff180) - 2025-10-10
 * [Issue] [Release 25.11.0](https://github.com/hyperledger/besu/issues/9366) - 2025-10-27
-* [Pull Request] []() - 2025-11-03
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-11-25
+* [Pull Request] [fix(getBlobs): return null if node is syncing](https://github.com/besu-eth/besu/pull/9394) - 2025-11-03
+* [Pull Request] [[do not merge] release-25.11.0-hotfix - CI](https://github.com/besu-eth/besu/pull/9398) - 2025-11-04
+* [Pull Request] [refactor: move NetworkName to better package and rename it](https://github.com/besu-eth/besu/pull/9490) - 2025-11-25
 
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [refactor: Remove peerTable outside of discv4 package](https://github.com/besu-eth/besu/pull/9579) - 2025-12-17
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-11-27
+* [Pull Request] [clients/besu: set `rpc-gas-cap` to 50M](https://github.com/ethereum/hive/pull/1373) - 2025-11-27
 
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2025-12-12
+* [Pull Request] [tests: rename MovePrecompileToAddress to movePrecompileToAddress](https://github.com/ethereum/execution-apis/pull/718) - 2025-12-12
 ## Q3 2025
 
 

--- a/members/gabrocheleau.md
+++ b/members/gabrocheleau.md
@@ -12,7 +12,7 @@ Team: EthereumJS
 
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-05
+* [Pull Request] [Add Gabriel Rocheleau contributions to ethjs](https://github.com/protocolguild/documentation/pull/454) - 2026-01-05
 * [Pull Request] []() - 2026-01-06
 
 [ethereum/pm](https://github.com/ethereum/pm)
@@ -20,15 +20,15 @@ Team: EthereumJS
 
 * [Issue] [Stateless Implementer's Call #49, February 23rd, 2026](https://github.com/ethereum/pm/issues/1919) - 2026-02-10
 [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo)
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [docs: add comments for bytesToUnprefixed strings](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4212) - 2026-01-15
 * [Issue] [Glamsterdam Hardfork Meta Issue](https://github.com/ethereumjs/ethereumjs-monorepo/issues/4238) - 2026-01-29
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [feat: add eip-7708 & 7843](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4239) - 2026-02-02
+* [Pull Request] [mpt: refactor, comment and simplify MPT class ](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4241) - 2026-02-10
 * [Pull Request] []() - 2026-02-12
 * [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-28
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [fix: npm audit fixes](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4255) - 2026-02-28
+* [Pull Request] [chore: downgrade dev bal 510](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4258) - 2026-03-05
+* [Pull Request] [evm: fix ethtransfer tests](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4259) - 2026-03-06
 * [Pull Request] []() - 2026-03-09
 ## Q4 2025
 
@@ -65,9 +65,9 @@ Team: EthereumJS
 * [Pull Request] [verkle: remove verkle package](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4145) - 2025-10-11
 * [Commit] [chore: cleanup verkle](https://github.com/ethereumjs/ethereumjs-monorepo/commit/83b0269efe4948b3267a1fa753e06c3488df5ec1) - 2025-10-11
 
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [chore: upgrade noble curves v2](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4183) - 2025-11-13
+* [Pull Request] [util: validate no leading zeroes7702](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4204) - 2025-11-28
+* [Pull Request] [common: fix hardforks implementation](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4216) - 2025-12-30
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [Stateless Implementers Call #44, October 20th, 2025](https://github.com/ethereum/pm/issues/1770) - 2025-10-17
 * [Issue] [Stateless Implementers Call #45, November 3rd, 2025](https://github.com/ethereum/pm/issues/1773) - 2025-10-20

--- a/members/garyschulte.md
+++ b/members/garyschulte.md
@@ -8,6 +8,13 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Aga
 
 ## Contributions
 
+## Q1 2026
+
+
+[hyperledger/besu](https://github.com/hyperledger/besu)
+* [Review] [Review on: 26.3.0-rc0 prep](https://github.com/besu-eth/besu/pull/10017#pullrequestreview-3924466419) - 2026-03-10
+* [Review] [Review on: Update GitHub repo references for org migration to besu-eth](https://github.com/besu-eth/besu/pull/10015#pullrequestreview-3924160010) - 2026-03-10
+* [Review] [Review on: Update GitHub repo references for org migration to besu-eth](https://github.com/besu-eth/besu/pull/10015#pullrequestreview-3924326693) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/garyschulte.md
+++ b/members/garyschulte.md
@@ -12,8 +12,8 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Aga
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2025-10-21
-* [Pull Request] []() - 2025-10-25
+* [Pull Request] [make BesuVersionUtils graal-safe](https://github.com/besu-eth/besu/pull/9342) - 2025-10-21
+* [Pull Request] [Allow setting an explicit SignatureAlgorithm instance](https://github.com/besu-eth/besu/pull/9364) - 2025-10-25
 ## Q3 2025
 
 

--- a/members/gballet.md
+++ b/members/gballet.md
@@ -21,6 +21,8 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 * [Pull Request] [trie, cmd/geth: add archiver command](https://github.com/gballet/go-ethereum/pull/563) - 2026-01-25
 * [Pull Request] [first solution](https://github.com/gballet/go-ethereum/pull/565) - 2026-02-07
 * [Pull Request] [various bugfixes found while testing](https://github.com/gballet/go-ethereum/pull/570) - 2026-03-04
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3921626308) - 2026-03-10
+* [Review] [Review on: trie/bintrie: fix grouped InternalNode serialization path mismatch](https://github.com/gballet/go-ethereum/pull/569#pullrequestreview-3923670025) - 2026-03-10
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
 * [Pull Request] [cmd/keeper, metrics: tamago build + zisk support](https://github.com/ethereum/go-ethereum/pull/33678) - 2026-01-24
 * [Pull Request] [cmd/keeper: export getInput in wasm builds](https://github.com/ethereum/go-ethereum/pull/33686) - 2026-01-26
@@ -31,6 +33,9 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 * [Pull Request] [trie/bintrie: fix endianness in code chunk key computation](https://github.com/ethereum/go-ethereum/pull/33900) - 2026-02-27
 * [Pull Request] [core: fix TestProcessVerkle flaky test](https://github.com/ethereum/go-ethereum/pull/33971) - 2026-03-06
 
+* [Review] [Review on: cmd/geth: add Prague pruning points](https://github.com/ethereum/go-ethereum/pull/33657#pullrequestreview-3924933292) - 2026-03-10
+* [Review] [Review on: core/tracing: fix nonce revert edge case](https://github.com/ethereum/go-ethereum/pull/33978#pullrequestreview-3923530275) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3920343071) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Update EIP-7864: encode offset as big endian](https://github.com/ethereum/EIPs/pull/11389) - 2026-03-09
 ## Q4 2025

--- a/members/gballet.md
+++ b/members/gballet.md
@@ -12,27 +12,27 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 
 
 [gballet/go-ethereum](https://github.com/gballet/go-ethereum)
-* [Pull Request] []() - 2026-01-12
+* [Pull Request] [trie: introduce expired nodes](https://github.com/gballet/go-ethereum/pull/556) - 2026-01-12
 * [Issue] [expired nodes: figure a better encoding for paths](https://github.com/gballet/go-ethereum/issues/559) - 2026-01-19
 * [Issue] [expired nodes: use better encoding](https://github.com/gballet/go-ethereum/issues/558) - 2026-01-19
 * [Issue] [expired nodes: don't resurrect siblings, just update in-place](https://github.com/gballet/go-ethereum/issues/557) - 2026-01-19
 * [Pull Request] []() - 2026-01-20
 
-* [Pull Request] []() - 2026-01-25
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-03-04
+* [Pull Request] [trie, cmd/geth: add archiver command](https://github.com/gballet/go-ethereum/pull/563) - 2026-01-25
+* [Pull Request] [first solution](https://github.com/gballet/go-ethereum/pull/565) - 2026-02-07
+* [Pull Request] [various bugfixes found while testing](https://github.com/gballet/go-ethereum/pull/570) - 2026-03-04
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-24
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [cmd/keeper, metrics: tamago build + zisk support](https://github.com/ethereum/go-ethereum/pull/33678) - 2026-01-24
+* [Pull Request] [cmd/keeper: export getInput in wasm builds](https://github.com/ethereum/go-ethereum/pull/33686) - 2026-01-26
+* [Pull Request] [cmd/geth: add subcommand for offline binary tree conversion](https://github.com/ethereum/go-ethereum/pull/33740) - 2026-02-02
+* [Pull Request] [trie/bintrie: fix debug_executionWitness for binary tree](https://github.com/ethereum/go-ethereum/pull/33739) - 2026-02-03
+* [Pull Request] [AGENTS.md: add AGENTS.md with guidelines for AI agents](https://github.com/ethereum/go-ethereum/pull/33890) - 2026-02-24
+* [Pull Request] [trie, cmd/geth: resurrect trie nodes from archive + archival command](https://github.com/ethereum/go-ethereum/pull/33906) - 2026-02-26
+* [Pull Request] [trie/bintrie: fix endianness in code chunk key computation](https://github.com/ethereum/go-ethereum/pull/33900) - 2026-02-27
+* [Pull Request] [core: fix TestProcessVerkle flaky test](https://github.com/ethereum/go-ethereum/pull/33971) - 2026-03-06
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Update EIP-7864: encode offset as big endian](https://github.com/ethereum/EIPs/pull/11389) - 2026-03-09
 ## Q4 2025
 
 
@@ -45,12 +45,12 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 * [Pull Request] [fix Stateless Consensus merging issue](https://github.com/protocolguild/documentation/pull/435) - 2025-10-07
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [.github: add 32-bit CI targets](https://github.com/ethereum/go-ethereum/pull/32911) - 2025-10-14
+* [Pull Request] [crypto: implement ziren keccak state](https://github.com/ethereum/go-ethereum/pull/32996) - 2025-10-22
 
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [trie, go.mod: remove all references to go-verkle and go-ipa](https://github.com/ethereum/go-ethereum/pull/33461) - 2025-12-19
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [Update EIP-2926: refine transition description and refer to 8032](https://github.com/ethereum/EIPs/pull/10629) - 2025-10-27
 ## Q3 2025
 
 

--- a/members/gfukushima.md
+++ b/members/gfukushima.md
@@ -21,6 +21,9 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Agfukus
 
 [Consensys/teku](https://github.com/Consensys/teku)
 * [Pull Request] [Add option to enable blobdb on RocksDB](https://github.com/Consensys/teku/pull/10470) - 2026-03-10
+* [Review] [Review on: Change getPayload timeout to 2s](https://github.com/Consensys/teku/pull/10473#pullrequestreview-3926283500) - 2026-03-11
+* [Review] [Review on: Engine api optimizations](https://github.com/Consensys/teku/pull/10469#pullrequestreview-3919400844) - 2026-03-10
+* [Review] [Review on: Added deprecation warning for leveldb databases](https://github.com/Consensys/teku/pull/10468#pullrequestreview-3919350091) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/gfukushima.md
+++ b/members/gfukushima.md
@@ -12,25 +12,28 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Agfukus
 
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-11
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Single block provider fulu](https://github.com/Consensys/teku/pull/10264) - 2026-01-09
+* [Pull Request] [Update earliest available data column slot after pruning](https://github.com/Consensys/teku/pull/10265) - 2026-01-11
+* [Pull Request] [Fix first non finalized slot calculation ](https://github.com/Consensys/teku/pull/10270) - 2026-01-12
+* [Pull Request] [Add AT test for `--rest-api-getblobs-sidecars-download-enabled`](https://github.com/Consensys/teku/pull/10286) - 2026-01-21
 * [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [Enable gossip during optimistic sync for data columns](https://github.com/Consensys/teku/pull/10304) - 2026-02-18
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [Add option to enable blobdb on RocksDB](https://github.com/Consensys/teku/pull/10470) - 2026-03-10
 ## Q4 2025
 
 
 [consensys/teku](https://github.com/consensys/teku)
 * [Commit] [[Stateless Proto] Introducing execution proofs subnet and gossip validation (#9869)](https://github.com/Consensys/teku/commit/63af7e23107144747a84c7692a46c6a142cda99a) - 2025-10-08
-* [Pull Request] []() - 2025-10-17
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-11-06
+* [Pull Request] [[Stateless Proto] Add flag to set execution proof generation artificial delay](https://github.com/Consensys/teku/pull/10027) - 2025-10-17
+* [Pull Request] [[Stateless Proto] Execution proof availability checker](https://github.com/Consensys/teku/pull/10097) - 2025-11-04
+* [Pull Request] [Update besu version to 25.11](https://github.com/Consensys/teku/pull/10106) - 2025-11-06
 * [Issue] [Add a mechanism to markForEquivocation for Fulu](https://github.com/Consensys/teku/issues/10133) - 2025-11-13
-* [Pull Request] []() - 2025-11-17
+* [Pull Request] [Mark for equivocation datacolumns recovered from EL](https://github.com/Consensys/teku/pull/10143) - 2025-11-17
 * [Issue] [Refine the concept of Gossip data columns sidecars validation failure ](https://github.com/Consensys/teku/issues/10149) - 2025-11-19
-* [Pull Request] []() - 2025-11-25
-* [Pull Request] []() - 2025-12-04
+* [Pull Request] [Add Single block provider for Fulu ](https://github.com/Consensys/teku/pull/10169) - 2025-11-25
+* [Pull Request] [disable flaky test](https://github.com/Consensys/teku/pull/10202) - 2025-12-04
 * [Issue] [Investigate flakiness of Das50PercentRecoveryAcceptanceTest](https://github.com/Consensys/teku/issues/10206) - 2025-12-07
 * [Issue] [SingleBlockProvider for Fulu](https://github.com/Consensys/teku/issues/10208) - 2025-12-08
 ## Q3 2025

--- a/members/giulio2002.md
+++ b/members/giulio2002.md
@@ -36,6 +36,8 @@ Team: Erigon
 * [Pull Request] [[SharovBot] fix(shutter): wait for pending nonce after block build to prevent flaky TestShutterBlockBuilding](https://github.com/erigontech/erigon/pull/19782) - 2026-03-10
 * [Pull Request] [[SharovBot] ci: increase test timeout to 30m on windows-2025 to fix eest_blockchain marginal failure](https://github.com/erigontech/erigon/pull/19771) - 2026-03-10
 * [Commit] [[SharovBot] ci: increase test timeout to 30m on windows-2025 to fix eest_blockchain marginal failure (#19771)](https://github.com/erigontech/erigon/commit/ae876c6ee377db01d56834d6002f62755b1cee11) - 2026-03-10
+* [Review] [Review on: cl/beacon: fix nil pointer panics in GetEthV1ValidatorAttestationData](https://github.com/erigontech/erigon/pull/19783#pullrequestreview-3925656618) - 2026-03-10
+* [Review] [Review on: mark `commitment history` feature as non-experimental](https://github.com/erigontech/erigon/pull/19774#pullrequestreview-3924713020) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Add EIP: Engine API Communication Channels](https://github.com/ethereum/EIPs/pull/11360) - 2026-02-28
 
@@ -43,6 +45,9 @@ Team: Erigon
 * [Commit] [Add EIP: Binary SSZ Transport for the Engine API](https://github.com/ethereum/EIPs/commit/73afb6b4d30b0430ff8fb29b09bddb5ace928c9a) - 2026-03-10
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
 * [Pull Request] [engine: add engine_exchangeCapabilitiesV2](https://github.com/ethereum/execution-apis/pull/766) - 2026-03-05
+
+[protocolguild/documentation](https://github.com/protocolguild/documentation)
+* [Review] [Review on: Update Erigon contributions with Zilkworm link](https://github.com/protocolguild/documentation/pull/478#pullrequestreview-3923365067) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/giulio2002.md
+++ b/members/giulio2002.md
@@ -12,33 +12,37 @@ Team: Erigon
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-02
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-08
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-02-21
+* [Pull Request] [Caplin: Global Active Validator Caches](https://github.com/erigontech/erigon/pull/18525) - 2026-01-02
+* [Pull Request] [Caplin: fill global active validators cache but keep totalActiveBalance=0 if we dont know effective balances](https://github.com/erigontech/erigon/pull/18554) - 2026-01-05
+* [Pull Request] [Erigon: fix the disgusting commitment value transformer](https://github.com/erigontech/erigon/pull/18561) - 2026-01-06
+* [Pull Request] [Fix concurrent map write in subscriber log](https://github.com/erigontech/erigon/pull/18577) - 2026-01-07
+* [Pull Request] [Performance: increase steps required for evm.Cancelled()](https://github.com/erigontech/erigon/pull/18903) - 2026-01-31
+* [Pull Request] [Performance: parallel tx hashes warm](https://github.com/erigontech/erigon/pull/18913) - 2026-02-02
+* [Pull Request] [State cache flag in experiments.go](https://github.com/erigontech/erigon/pull/18930) - 2026-02-03
+* [Pull Request] [Disable state cache momentairily](https://github.com/erigontech/erigon/pull/18946) - 2026-02-04
+* [Pull Request] [Improve read-ahead for chain tip](https://github.com/erigontech/erigon/pull/18987) - 2026-02-08
+* [Pull Request] [Caplin: to not insert frozen blocks](https://github.com/erigontech/erigon/pull/19036) - 2026-02-09
+* [Pull Request] [Performance: skip unwind when unneded.](https://github.com/erigontech/erigon/pull/19033) - 2026-02-10
+* [Pull Request] [[SharovBot] ci: skip sync wait if node already synced in rpc-integ-tests-latest](https://github.com/erigontech/erigon/pull/19374) - 2026-02-20
+* [Pull Request] [[SharovBot] fix(txpool): comprehensive stale tx eviction for pending and queued sub-pools](https://github.com/erigontech/erigon/pull/19394) - 2026-02-21
 * [Issue] [eth_getLogs / eth_getTransactionReceipt returns wrong/missing logs for specific transactions (receipt computation bug)](https://github.com/erigontech/erigon/issues/19406) - 2026-02-22
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [[SharovBot] fix Amsterdam signer support and BAL non-determinism](https://github.com/erigontech/erigon/pull/19434) - 2026-02-23
+* [Pull Request] [[SharovBot] ci: enable Docker layer caching for Hive workflows](https://github.com/erigontech/erigon/pull/19468) - 2026-02-24
 * [Issue] [[SharovBot] security: taratorio (weak boy) attempted social engineering attack](https://github.com/erigontech/erigon/issues/19452) - 2026-02-24
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [[SharovBot] test: split parallel test into test+benchmark to fix CI disk exhaustion](https://github.com/erigontech/erigon/pull/19496) - 2026-02-25
 * [Issue] [QA: add second datadir for RPC integration tests (branch builds)](https://github.com/erigontech/erigon/issues/19521) - 2026-02-27
 
-* [Pull Request] []() - 2026-03-01
-* [Pull Request] []() - 2026-03-10
+* [Pull Request] [[WIP] SSZ-REST Engine API transport Big Secret](https://github.com/erigontech/erigon/pull/19551) - 2026-03-01
+* [Pull Request] [[SharovBot] fix(shutter): wait for pending nonce after block build to prevent flaky TestShutterBlockBuilding](https://github.com/erigontech/erigon/pull/19782) - 2026-03-10
+* [Pull Request] [[SharovBot] ci: increase test timeout to 30m on windows-2025 to fix eest_blockchain marginal failure](https://github.com/erigontech/erigon/pull/19771) - 2026-03-10
+* [Commit] [[SharovBot] ci: increase test timeout to 30m on windows-2025 to fix eest_blockchain marginal failure (#19771)](https://github.com/erigontech/erigon/commit/ae876c6ee377db01d56834d6002f62755b1cee11) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [Add EIP: Engine API Communication Channels](https://github.com/ethereum/EIPs/pull/11360) - 2026-02-28
 
+* [Pull Request] [Add EIP: Binary SSZ Transport for the Engine API](https://github.com/ethereum/EIPs/pull/11365) - 2026-03-10
+* [Commit] [Add EIP: Binary SSZ Transport for the Engine API](https://github.com/ethereum/EIPs/commit/73afb6b4d30b0430ff8fb29b09bddb5ace928c9a) - 2026-03-10
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [engine: add engine_exchangeCapabilitiesV2](https://github.com/ethereum/execution-apis/pull/766) - 2026-03-05
 ## Q4 2025
 
 
@@ -50,11 +54,11 @@ Team: Erigon
 * [Commit] [save](https://github.com/erigontech/erigon/commit/d3b3ad36d05cc9f50fa401d6cea25d3426e36334) - 2025-10-06
 * [Issue] [Cannot sync gnosis from scrath (needed for historical eth_getProof)](https://github.com/erigontech/erigon/issues/17430) - 2025-10-12
 * [Issue] [Bug in EpochData marshalling in Antiquary](https://github.com/erigontech/erigon/issues/17476) - 2025-10-15
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-10-29
-* [Pull Request] []() - 2025-12-15
-* [Pull Request] []() - 2025-12-24
-* [Pull Request] []() - 2025-12-26
+* [Pull Request] [Cherry-Pick: Add cli tool to fetch and recover blobs from a remote beacon api. (#1…](https://github.com/erigontech/erigon/pull/17611) - 2025-10-23
+* [Pull Request] [Caplin: downscore peer sending attestations not in range](https://github.com/erigontech/erigon/pull/17705) - 2025-10-29
+* [Pull Request] [Cherry-pick: Refactor: Extract BlobHistoryDownloader into dedicated struct (#18269)](https://github.com/erigontech/erigon/pull/18314) - 2025-12-15
+* [Pull Request] [Revert "half block exec fix in receipts"](https://github.com/erigontech/erigon/pull/18462) - 2025-12-24
+* [Pull Request] [Fixed false positive data race.](https://github.com/erigontech/erigon/pull/18479) - 2025-12-26
 ## Q3 2025
 
 

--- a/members/gurukamath.md
+++ b/members/gurukamath.md
@@ -13,12 +13,12 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Check default values and types in genesis files](https://github.com/ethereum/execution-specs/issues/2018) - 2026-01-13
-* [Pull Request] []() - 2026-01-16
+* [Pull Request] [tests(eip-7928): generalize eip-7934 tests](https://github.com/ethereum/execution-specs/pull/2022) - 2026-01-16
 * [Issue] [bug(specs): Re-evaluvate the types of the Block dataclass](https://github.com/ethereum/execution-specs/issues/2054) - 2026-01-21
-* [Pull Request] []() - 2026-01-21
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-24
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [fix(tests): fix legacy tests to run with eip-7778](https://github.com/ethereum/execution-specs/pull/2048) - 2026-01-21
+* [Pull Request] [feat(spec-tests): add eip-7778 tests for calldata checks](https://github.com/ethereum/execution-specs/pull/2060) - 2026-01-22
+* [Pull Request] [feat(spec-specs): (EIP-7778) revert to post refund gas in receipts](https://github.com/ethereum/execution-specs/pull/2073) - 2026-01-24
+* [Pull Request] [feat(tests): BAL tests for 7702 delegation reset, create and access](https://github.com/ethereum/execution-specs/pull/2097) - 2026-02-06
 
 * [Issue] [Refactor State related code](https://github.com/ethereum/execution-specs/issues/2228) - 2026-02-18
 * [Issue] [Add optimized runs in CI](https://github.com/ethereum/execution-specs/issues/2256) - 2026-02-20
@@ -26,7 +26,7 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Create test for same block system contract deployment](https://github.com/ethereum/execution-specs/issues/2270) - 2026-02-21
 * [Issue] [Move `set_delegation` before `process_message_call`](https://github.com/ethereum/execution-specs/issues/2338) - 2026-02-26
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [Update EIP-2780: Clarify interactions with other EIPs](https://github.com/ethereum/EIPs/pull/11332) - 2026-02-18
 ## Q4 2025
 
 
@@ -34,11 +34,11 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Commit] [chore(deps,tooling): bump ruff to latest version (#1445)](https://github.com/ethereum/execution-specs/commit/26c7daf42c968e0715fc69dbe6876c2a6a1601dd) - 2025-10-01
 * [Issue] [Address warmed on aborted call](https://github.com/ethereum/execution-specs/issues/1541) - 2025-10-09
 * [Issue] [Test to catch the alt_bn_128 issue](https://github.com/ethereum/execution-specs/issues/1539) - 2025-10-09
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-11-29
-* [Pull Request] []() - 2025-12-01
-* [Pull Request] []() - 2025-12-12
+* [Pull Request] [fix(tooling): Handle AnnAssign nodes in the new fork tool](https://github.com/ethereum/execution-specs/pull/1813) - 2025-11-26
+* [Pull Request] [refactor(tests): create fixture items for vm tests](https://github.com/ethereum/execution-specs/pull/1823) - 2025-11-28
+* [Pull Request] [fix(ci): run coverage from py3 instead of json_infra](https://github.com/ethereum/execution-specs/pull/1824) - 2025-11-29
+* [Pull Request] [enhance(test-tests): add more transaction validation tests](https://github.com/ethereum/execution-specs/pull/1826) - 2025-12-01
+* [Pull Request] [fix(ci): handle new branch push and other triggers](https://github.com/ethereum/execution-specs/pull/1913) - 2025-12-12
 ## Q3 2025
 
 

--- a/members/gurukamath.md
+++ b/members/gurukamath.md
@@ -25,6 +25,7 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Remove `set_authority_code` from Amsterdam](https://github.com/ethereum/execution-specs/issues/2246) - 2026-02-20
 * [Issue] [Create test for same block system contract deployment](https://github.com/ethereum/execution-specs/issues/2270) - 2026-02-21
 * [Issue] [Move `set_delegation` before `process_message_call`](https://github.com/ethereum/execution-specs/issues/2338) - 2026-02-26
+* [Review] [Review on: feat(t8n): handle pre-fork typed txs via `supports_tx_type`](https://github.com/ethereum/execution-specs/pull/2466#pullrequestreview-3924132051) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Update EIP-2780: Clarify interactions with other EIPs](https://github.com/ethereum/EIPs/pull/11332) - 2026-02-18
 ## Q4 2025

--- a/members/han0110.md
+++ b/members/han0110.md
@@ -10,27 +10,29 @@ Github: [@han0110](https://github.com/han0110)
 
 
 [eth-act/ere](https://github.com/eth-act/ere)
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [Fix CI condition when push to master](https://github.com/eth-act/ere/pull/276) - 2026-01-27
 * [Issue] [Update `ere-compiler` to output ELF bytes and program digest separately](https://github.com/eth-act/ere/issues/275) - 2026-01-27
 * [Issue] [Add `ProverResourceType::ClusterClient`](https://github.com/eth-act/ere/issues/277) - 2026-01-27
 
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-07
+* [Pull Request] [Bump workspace version to `v0.2.0`](https://github.com/eth-act/ere/pull/283) - 2026-02-03
+* [Pull Request] [Skip `jolt` in workflow `check-zkvm-version.yml`](https://github.com/eth-act/ere/pull/285) - 2026-02-04
+* [Pull Request] [Add macro `export_cycle_scope_names` in `ere-platform-zisk`](https://github.com/eth-act/ere/pull/289) - 2026-02-07
 * [Pull Request] []() - 2026-02-08
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [Build and publish cuda enabled docker image](https://github.com/eth-act/ere/pull/291) - 2026-02-10
 * [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [Bump workspace to `v0.3.0`](https://github.com/eth-act/ere/pull/293) - 2026-02-13
+* [Pull Request] [Update SP1 to `v6.0.0`](https://github.com/eth-act/ere/pull/294) - 2026-02-17
+* [Pull Request] [[WIP] Update ZisK to `0.16.0`](https://github.com/eth-act/ere/pull/296) - 2026-02-19
+* [Pull Request] [Update `miden` to `v0.21.0`](https://github.com/eth-act/ere/pull/298) - 2026-02-23
 * [Pull Request] []() - 2026-02-24
 * [Issue] [Add `metadata` support in `/prove` API of `ere-server`](https://github.com/eth-act/ere/issues/303) - 2026-02-27
 * [Issue] [Add support for cancelling an ongoing proving process](https://github.com/eth-act/ere/issues/302) - 2026-02-27
 * [Issue] [Allow disable ZisK prover logging](https://github.com/eth-act/ere/issues/301) - 2026-02-27
+* [Pull Request] [Remove some zkVMs](https://github.com/eth-act/ere/pull/307) - 2026-03-10
+* [Commit] [Remove some zkVMs (#307)](https://github.com/eth-act/ere/commit/664955e671e4f191dc1acbf490cd04f4451f4d5c) - 2026-03-10
 [eth-act/zkboost](https://github.com/eth-act/zkboost)
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-16
-* [Issue] [Add API and simple web UI for metrics in zkboost/EWS](https://github.com/eth-act/zkboost/issues/38) - 2026-02-27
+* [Pull Request] [Integrate zkboost into EWS](https://github.com/eth-act/zkboost/pull/30) - 2026-01-29
+* [Pull Request] [zkboost support mock zkvm](https://github.com/eth-act/zkboost/pull/35) - 2026-01-30
+* [Pull Request] [Add mermaid sequence diagram for `testnet` example](https://github.com/eth-act/zkboost/pull/36) - 2026-02-02
+* [Pull Request] [Update ere to `v0.3.0`](https://github.com/eth-act/zkboost/pull/37) - 2026-02-16
+* [Issue] [Add API and simple web UI for metrics in zkboost/EWS](https://github.com/eth-act/zkboost/issues/38) - 2026-02-27* [Pull Request] [Rework zkboost to implement proof node API](https://github.com/eth-act/zkboost/pull/39) - 2026-03-10

--- a/members/han0110.md
+++ b/members/han0110.md
@@ -28,6 +28,7 @@ Github: [@han0110](https://github.com/han0110)
 * [Issue] [Add `metadata` support in `/prove` API of `ere-server`](https://github.com/eth-act/ere/issues/303) - 2026-02-27
 * [Issue] [Add support for cancelling an ongoing proving process](https://github.com/eth-act/ere/issues/302) - 2026-02-27
 * [Issue] [Allow disable ZisK prover logging](https://github.com/eth-act/ere/issues/301) - 2026-02-27
+* [Pull Request] []() - 2026-03-10
 [eth-act/zkboost](https://github.com/eth-act/zkboost)
 * [Pull Request] []() - 2026-01-29
 * [Pull Request] []() - 2026-01-30

--- a/members/hangleang.md
+++ b/members/hangleang.md
@@ -11,16 +11,16 @@ Team: [Grandine](https://github.com/grandinetech/grandine)
 
 
 [grandinetech/grandine](https://github.com/grandinetech/grandine)
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-16
+* [Pull Request] [Set proposer boost for first timely block from the expected proposer](https://github.com/grandinetech/grandine/pull/561) - 2026-01-07
+* [Pull Request] [Refactor and fix bugs in ePBS changes](https://github.com/grandinetech/grandine/pull/570) - 2026-01-13
+* [Pull Request] [Onboard builders at the fork](https://github.com/grandinetech/grandine/pull/575) - 2026-01-26
+* [Pull Request] [Handle `ExecutionPayloadBid` via gossip](https://github.com/grandinetech/grandine/pull/582) - 2026-01-30
+* [Pull Request] [Update `prepare_execution_payload` for Gloas](https://github.com/grandinetech/grandine/pull/583) - 2026-01-31
+* [Pull Request] [Handle `ExecutionPayloadEnvelope`](https://github.com/grandinetech/grandine/pull/591) - 2026-02-04
+* [Pull Request] [Update `POST /eth/v2/beacon/blocks` to publish only signed beacon block for post-Gloas](https://github.com/grandinetech/grandine/pull/600) - 2026-02-10
+* [Pull Request] [`GET /eth/v2/node/version`](https://github.com/grandinetech/grandine/pull/599) - 2026-02-11
+* [Pull Request] [Send full signed execution payload bid to event stream](https://github.com/grandinetech/grandine/pull/601) - 2026-02-13
+* [Pull Request] [Add payload attestation tick](https://github.com/grandinetech/grandine/pull/603) - 2026-02-16
 ## Q4 2025
 
 
@@ -40,20 +40,20 @@ Team: [Grandine](https://github.com/grandinetech/grandine)
 * [Issue] [Add Gloas helper, state transition functions](https://github.com/grandinetech/grandine/issues/417) - 2025-10-13
 * [Commit] [Support the `/eth/v2/builder/blinded_blocks` post-fulu](https://github.com/grandinetech/grandine/commit/1b4cf58a9288ddd85a5b25337ca05a6b376aabbd) - 2025-10-13
 * [Issue] [Add a feature to disable finalized root check in status message](https://github.com/grandinetech/grandine/issues/416) - 2025-10-13
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [Ensure data column sidecars respect the blob limit](https://github.com/grandinetech/grandine/pull/425) - 2025-10-15
 * [Issue] [Gloas: PTC assignments](https://github.com/grandinetech/grandine/issues/444) - 2025-10-24
 
-* [Pull Request] []() - 2025-11-20
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-04
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-17
-* [Pull Request] []() - 2025-12-19
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [Migrate `BeaconBlockBody` to feature based traits](https://github.com/grandinetech/grandine/pull/489) - 2025-11-20
+* [Pull Request] [Validator API: update `attestation_data` and disable `blockV3` for Gloas](https://github.com/grandinetech/grandine/pull/508) - 2025-12-03
+* [Pull Request] [`GET /eth/v1/validator/execution_payload_bid/{slot}/{builder_index}`](https://github.com/grandinetech/grandine/pull/518) - 2025-12-04
+* [Pull Request] [Handle block payload attestations](https://github.com/grandinetech/grandine/pull/537) - 2025-12-16
+* [Pull Request] [Delay execution payload envelope until data available](https://github.com/grandinetech/grandine/pull/538) - 2025-12-17
+* [Pull Request] [Add `block_gossip` SSE stream](https://github.com/grandinetech/grandine/pull/543) - 2025-12-19
+* [Pull Request] [Clean up: remove data column debug flags](https://github.com/grandinetech/grandine/pull/546) - 2025-12-23
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [Clean up Gloas specs (part 6)](https://github.com/ethereum/consensus-specs/pull/4741) - 2025-11-13
+* [Pull Request] [Move `get_data_column_sidecars_from_column_sidecar` to builder spec](https://github.com/ethereum/consensus-specs/pull/4783) - 2025-12-09
+* [Pull Request] [Remove `slot` from `get_indexed_payload_attestation`](https://github.com/ethereum/consensus-specs/pull/4797) - 2025-12-18
 ## Q3 2025
 
 

--- a/members/healthykim.md
+++ b/members/healthykim.md
@@ -12,4 +12,5 @@ Github: [@healthykim](https://github.com/healthykim)
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
 * [Pull Request] [core, eth: add new subscribe function for tx hashes](https://github.com/ethereum/go-ethereum/pull/33793) - 2026-02-08
 * [Pull Request] [core/txpool/blobpool: return `txpool.ErrUnderpriced` on eviction ](https://github.com/ethereum/go-ethereum/pull/33806) - 2026-02-09
-* [Pull Request] [eth/protocols/eth: drop protocol version eth/68](https://github.com/ethereum/go-ethereum/pull/33511) - 2026-02-28
+* [Pull Request] [eth/protocols/eth: drop protocol version eth/68](https://github.com/ethereum/go-ethereum/pull/33511) - 2026-02-28* [Review] [Review on: core/txpool/legacypool: Fix overdraft DoS attack in the legacy pool](https://github.com/ethereum/go-ethereum/pull/33492#pullrequestreview-3919114806) - 2026-03-10
+* [Review] [Review on: core/txpool/legacypool: Fix overdraft DoS attack in the legacy pool](https://github.com/ethereum/go-ethereum/pull/33492#pullrequestreview-3919126232) - 2026-03-10

--- a/members/healthykim.md
+++ b/members/healthykim.md
@@ -10,6 +10,6 @@ Github: [@healthykim](https://github.com/healthykim)
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-02-08
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [core, eth: add new subscribe function for tx hashes](https://github.com/ethereum/go-ethereum/pull/33793) - 2026-02-08
+* [Pull Request] [core/txpool/blobpool: return `txpool.ErrUnderpriced` on eviction ](https://github.com/ethereum/go-ethereum/pull/33806) - 2026-02-09
+* [Pull Request] [eth/protocols/eth: drop protocol version eth/68](https://github.com/ethereum/go-ethereum/pull/33511) - 2026-02-28

--- a/members/inspector-butters.md
+++ b/members/inspector-butters.md
@@ -10,8 +10,10 @@ Github: [@inspector-butters](https://github.com/inspector-butters)
 
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-03-08
+* [Pull Request] [add path field for ephemeral log file initialization](https://github.com/OffchainLabs/prysm/pull/16289) - 2026-01-27
+* [Pull Request] [Fix gen-logs.sh - gitignore bug](https://github.com/OffchainLabs/prysm/pull/16328) - 2026-02-04
+* [Pull Request] [GetVersionV2 endpoint](https://github.com/OffchainLabs/prysm/pull/16347) - 2026-02-09
+* [Pull Request] [add log.go files to runtime](https://github.com/OffchainLabs/prysm/pull/16491) - 2026-03-08
 * [Issue] ["Could not get state" when calling debug/states endpoint](https://github.com/OffchainLabs/prysm/issues/16497) - 2026-03-08
+[OffchainLabs/prysm](https://github.com/OffchainLabs/prysm)
+* [Pull Request] [Progressive Merkle Tree Core Algorithm (EIP-7916)](https://github.com/OffchainLabs/prysm/pull/16507) - 2026-03-10

--- a/members/james-prysm.md
+++ b/members/james-prysm.md
@@ -12,12 +12,12 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Ajames-prys
 
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [constants update for ethspecify phase 0](https://github.com/OffchainLabs/prysm/pull/16273) - 2026-01-22
+* [Pull Request] [Update health endpoint to include sync and optimistic checks ](https://github.com/OffchainLabs/prysm/pull/16294) - 2026-01-27
 * [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [Add payload attestation pool for PTC (Gloas)](https://github.com/OffchainLabs/prysm/pull/16308) - 2026-01-30
+* [Pull Request] [gloas events ( without triggers)](https://github.com/OffchainLabs/prysm/pull/16323) - 2026-02-03
+* [Pull Request] [simplify get and post block parsing for REST](https://github.com/OffchainLabs/prysm/pull/16307) - 2026-02-10
 * [Issue] [Gloas Attestation Gossip Changes](https://github.com/OffchainLabs/prysm/issues/16360) - 2026-02-13
 * [Issue] [Gloas block gossip](https://github.com/OffchainLabs/prysm/issues/16372) - 2026-02-18
 * [Issue] [gloas attestation](https://github.com/OffchainLabs/prysm/issues/16393) - 2026-02-23
@@ -30,7 +30,13 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Ajames-prys
 * [Issue] [ExecutionPayloadEnvelopesByRoot](https://github.com/OffchainLabs/prysm/issues/16400) - 2026-02-25
 * [Issue] [Gloas Sync Package changes](https://github.com/OffchainLabs/prysm/issues/16453) - 2026-03-02
 * [Issue] [rename of SECONDS_PER_SLOT to SLOT_DURATION_MS](https://github.com/OffchainLabs/prysm/issues/16484) - 2026-03-06
-* [Pull Request] []() - 2026-03-10
+* [Pull Request] [break out distributed validator components via an abstracted aggregator selector](https://github.com/OffchainLabs/prysm/pull/16509) - 2026-03-10
+
+[OffchainLabs/prysm](https://github.com/OffchainLabs/prysm)
+* [Pull Request] [adding payload attestation apis connection from validator client](https://github.com/OffchainLabs/prysm/pull/16504) - 2026-03-10
+* [Pull Request] [adding payload_attestation_message event](https://github.com/OffchainLabs/prysm/pull/16506) - 2026-03-10
+* [Pull Request] [fix to attestation pool to only consume on insert](https://github.com/OffchainLabs/prysm/pull/16503) - 2026-03-10
+* [Commit] [adding payload attestation apis connection from validator client (#16504)](https://github.com/OffchainLabs/prysm/commit/b17f2752ab2964366002d7beaaecb47a80f6e8cb) - 2026-03-10
 ## Q4 2025
 
 
@@ -62,9 +68,9 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Ajames-prys
 * [Commit] [we don't actually need to use the ids](https://github.com/OffchainLabs/prysm/commit/a37bc1cbd087af93a6dc860caf44fbfec81bb0ef) - 2025-10-13
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2025-11-25
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [adding debounce to remote key manager](https://github.com/OffchainLabs/prysm/pull/16051) - 2025-11-25
+* [Pull Request] [fixing state replay caused by REST api duties attester and sync committee endpoints](https://github.com/OffchainLabs/prysm/pull/16136) - 2025-12-12
+* [Pull Request] [changing isHealthy to isReady](https://github.com/OffchainLabs/prysm/pull/16167) - 2025-12-18
 ## Q3 2025
 
 

--- a/members/jangko.md
+++ b/members/jangko.md
@@ -12,14 +12,14 @@ Team: [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/commits?a
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-14
+* [Pull Request] [Use minimized mcl library](https://github.com/status-im/nimbus-eth1/pull/3915) - 2026-01-16
+* [Pull Request] [BAL-devnet-2: EIP-7708: ETH transfers emit a log](https://github.com/status-im/nimbus-eth1/pull/3933) - 2026-01-27
+* [Pull Request] [BAL-devnet-2: EIP-7843: SLOTNUM opcode](https://github.com/status-im/nimbus-eth1/pull/3939) - 2026-01-28
+* [Pull Request] [Simplify EVM flags](https://github.com/status-im/nimbus-eth1/pull/3951) - 2026-01-31
+* [Pull Request] [Bal devnet 2](https://github.com/status-im/nimbus-eth1/pull/3952) - 2026-02-01
+* [Pull Request] [Refactor calculateAndPossiblyRefundGas closer to to EIP-7623 and prepare for EIP-7778](https://github.com/status-im/nimbus-eth1/pull/3962) - 2026-02-02
+* [Pull Request] [Remove unused EVM opcodes](https://github.com/status-im/nimbus-eth1/pull/3964) - 2026-02-03
+* [Pull Request] [Fix nightly build: Run binary section execute 'nimbus' instead of 'nimbus_execution_client'](https://github.com/status-im/nimbus-eth1/pull/3980) - 2026-02-14
 * [Issue] [Unusual database access of ledger's clearStorage](https://github.com/status-im/nimbus-eth1/issues/4024) - 2026-02-27
 ## Q4 2025
 
@@ -42,10 +42,10 @@ Team: [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/commits?a
 * [Commit] [Use mcl to boost alt_bn128 precompiles performance (#3747)](https://github.com/status-im/nimbus-eth1/commit/552755a924019c640772c2a76a6f81f54f4f9f52) - 2025-10-08
 * [Commit] [Validate public key](https://github.com/status-im/nimbus-eth1/commit/2c3b2b58511ed033742fdd7b1411fa3c80cd20b7) - 2025-10-11
 * [Commit] [Update test log](https://github.com/status-im/nimbus-eth1/commit/3eb951c900ea58e5ae21156ee9682cdbef1cc7eb) - 2025-10-11
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [Fix rocksdb cache of verified proxy CI](https://github.com/status-im/nimbus-eth1/pull/3767) - 2025-10-15
+* [Pull Request] [Remove remnant of holesky from Makefile](https://github.com/status-im/nimbus-eth1/pull/3787) - 2025-10-23
+* [Pull Request] [Improves keccak256 perf](https://github.com/status-im/nimbus-eth1/pull/3866) - 2025-12-10
+* [Pull Request] [Tidying up bls precompiles](https://github.com/status-im/nimbus-eth1/pull/3870) - 2025-12-11
 * [Pull Request] []() - 2025-12-29
 ## Q3 2025
 

--- a/members/jflo.md
+++ b/members/jflo.md
@@ -16,12 +16,17 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Issue] [Inconsistent state on newBlock websocket subscriptions.](https://github.com/hyperledger/besu/issues/9682) - 2026-01-26
 
 * [Issue] [Migrate repository from hyperledger to besu-eth organization](https://github.com/hyperledger/besu/issues/9911) - 2026-02-26
+* [Pull Request] [26.3.0-rc0 prep](https://github.com/besu-eth/besu/pull/10017) - 2026-03-10
+* [Pull Request] [Update GitHub repo references for org migration to besu-eth](https://github.com/besu-eth/besu/pull/10015) - 2026-03-10
+* [Issue] [26.3.0-RC0](https://github.com/besu-eth/besu/issues/10016) - 2026-03-10
+* [Commit] [26.3.0-rc0 prep (#10017)](https://github.com/besu-eth/besu/commit/90687901b44948f364c5560213026c95f7ea543e) - 2026-03-10
+* [Commit] [Update GitHub repository references from hyperledger/besu to besu-eth/besu (#10015)](https://github.com/besu-eth/besu/commit/fc77470d2c683d09456c7bec0914af74fd1eb254) - 2026-03-10
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [Encrypt The Mempool #0, February 18, 2026](https://github.com/ethereum/pm/issues/1929) - 2026-02-16
 * [Issue] [Encrypt The Mempool #1, March 4, 2026](https://github.com/ethereum/pm/issues/1945) - 2026-02-23
 
 [hyperledger/besu-native](https://github.com/hyperledger/besu-native)
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [Update repo references from hyperledger to besu-eth org](https://github.com/besu-eth/besu-native/pull/307) - 2026-02-26
 * [Pull Request] []() - 2026-03-03
 ## Q4 2025
 
@@ -30,7 +35,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Pull Request] [proposes eip-7949 for inclusion in Glamsterdam](https://github.com/ethereum/EIPs/pull/10502) - 2025-10-09
 
 [ethereum/pm](https://github.com/ethereum/pm)
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [Add primary and backup coordinators for Besu](https://github.com/ethereum/pm/pull/1795) - 2025-11-05
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
 * [Issue] [[ETC Removal - Phase 2] Remove Tests and Update Documentation](https://github.com/hyperledger/besu/issues/9462) - 2025-11-18
@@ -51,7 +56,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Issue] [Move Forest storage system into a plugin](https://github.com/hyperledger/besu/issues/9447) - 2025-11-18
 * [Issue] [RPC Stack Refactor](https://github.com/hyperledger/besu/issues/9476) - 2025-11-20
 * [Issue] [attacknet - investigate as a tool to find bugs in besu](https://github.com/hyperledger/besu/issues/9525) - 2025-12-02
-* [Pull Request] []() - 2025-12-27
+* [Pull Request] [Treat EndOfRLPException as invalid packet in peer discovery](https://github.com/besu-eth/besu/pull/9597) - 2025-12-27
 * [Issue] [EndOfRLPException should be treated as invalid packet in peer discovery](https://github.com/hyperledger/besu/issues/9596) - 2025-12-27
 ## Q3 2025
 

--- a/members/jflo.md
+++ b/members/jflo.md
@@ -16,6 +16,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Issue] [Inconsistent state on newBlock websocket subscriptions.](https://github.com/hyperledger/besu/issues/9682) - 2026-01-26
 
 * [Issue] [Migrate repository from hyperledger to besu-eth organization](https://github.com/hyperledger/besu/issues/9911) - 2026-02-26
+* [Issue] [26.3.0-RC0](https://github.com/besu-eth/besu/issues/10016) - 2026-03-10
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [Encrypt The Mempool #0, February 18, 2026](https://github.com/ethereum/pm/issues/1929) - 2026-02-16
 * [Issue] [Encrypt The Mempool #1, March 4, 2026](https://github.com/ethereum/pm/issues/1945) - 2026-02-23

--- a/members/jframe.md
+++ b/members/jframe.md
@@ -37,6 +37,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Issue] [Bonsai Archive: Range presence index and bloom filters](https://github.com/hyperledger/besu/issues/9985) - 2026-03-06
 * [Issue] [Bonsai Archive: Index infrastructure with seekForPrev fallback](https://github.com/hyperledger/besu/issues/9984) - 2026-03-06
 * [Issue] [Bonsai Archive: Hybrid query routing](https://github.com/hyperledger/besu/issues/9981) - 2026-03-06
+* [Review] [Review on: disable forest TraceJsonRpcHttpBySpecTest](https://github.com/besu-eth/besu/pull/10005#pullrequestreview-3919369203) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/jframe.md
+++ b/members/jframe.md
@@ -15,7 +15,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Issue] [Bonsai archive sync as Bonsai the migrate to archive](https://github.com/hyperledger/besu/issues/9608) - 2026-01-07
 * [Issue] [Bonsai Archive sync halts on valid block due transaction nonce below sender error](https://github.com/hyperledger/besu/issues/9613) - 2026-01-09
 * [Issue] [Remove checkpoint](https://github.com/hyperledger/besu/issues/9684) - 2026-01-26
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [In BFT use configured mining beneficiary and allow 0 address](https://github.com/besu-eth/besu/pull/9706) - 2026-01-29
 * [Issue] [Bonsai Archive: Unify format options (remove X_ prefix)](https://github.com/hyperledger/besu/issues/9702) - 2026-01-28
 * [Issue] [Bonsai Archive: Remove or improve BonsaiArchivePartialFlatDbStrategy](https://github.com/hyperledger/besu/issues/9701) - 2026-01-28
 * [Issue] [Bonsai Archive: Index-based access to eliminate seekForPrev](https://github.com/hyperledger/besu/issues/9700) - 2026-01-28
@@ -25,12 +25,12 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ajf
 * [Issue] [Improve peer selection for world state download](https://github.com/hyperledger/besu/issues/9722) - 2026-02-02
 * [Issue] [Add peer performance metrics (transfer speed, latency, success rate)](https://github.com/hyperledger/besu/issues/9721) - 2026-02-02
 * [Issue] [Complete switch over to new peer task system for snap download](https://github.com/hyperledger/besu/issues/9719) - 2026-02-02
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [Remove peer task system toggle from DownloadHeadersStep](https://github.com/besu-eth/besu/pull/9760) - 2026-02-09
 * [Issue] [Besu release 26.2.0](https://github.com/hyperledger/besu/issues/9885) - 2026-02-24
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Update changelog for 26.2.0-RC2](https://github.com/besu-eth/besu/pull/9898) - 2026-02-26
+* [Pull Request] [revert snappy back to 1.1.10.7](https://github.com/besu-eth/besu/pull/9930) - 2026-03-02
+* [Pull Request] [fix: register AbstractPeerRequestTask timeout immediately to prevent BWS hang](https://github.com/besu-eth/besu/pull/9954) - 2026-03-04
+* [Pull Request] [Fix QBFT ProposalPayload backward compatibility with pre-26.1.0 Besu versions](https://github.com/besu-eth/besu/pull/9977) - 2026-03-06
 * [Issue] [Bonsai Archive: Cold storage deduplication](https://github.com/hyperledger/besu/issues/9989) - 2026-03-06
 * [Issue] [Bonsai Archive: Remove seekForPrev fallback](https://github.com/hyperledger/besu/issues/9987) - 2026-03-06
 * [Issue] [Bonsai Archive: Sub-blocking for hot accounts](https://github.com/hyperledger/besu/issues/9986) - 2026-03-06

--- a/members/jihoonsong.md
+++ b/members/jihoonsong.md
@@ -10,13 +10,13 @@ Github: [@jihoonsong](https://github.com/jihoonsong)
 
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-08
+* [Pull Request] [Organize `Helpers` and `Handlers` sections](https://github.com/ethereum/consensus-specs/pull/4819) - 2026-01-08
 
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [Rename execution_payload_states to payload_states](https://github.com/ethereum/consensus-specs/pull/4930) - 2026-02-16
+* [Pull Request] [Update execution proof construction to use beacon block](https://github.com/ethereum/consensus-specs/pull/4941) - 2026-02-19
+* [Pull Request] [Promote EIP-7805 to Heze](https://github.com/ethereum/consensus-specs/pull/4942) - 2026-02-20
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-11
+* [Pull Request] [Add primary contributions of Jihoon Song](https://github.com/protocolguild/documentation/pull/467) - 2026-01-11
 * [Pull Request] []() - 2026-01-12
 
 [ethereum/pm](https://github.com/ethereum/pm)
@@ -30,13 +30,13 @@ Github: [@jihoonsong](https://github.com/jihoonsong)
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Pull Request] [eip7805: add unit tests for `InclusionListStore`](https://github.com/ethereum/consensus-specs/pull/4644) - 2025-10-08
 
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-11-02
-* [Pull Request] []() - 2025-11-09
+* [Pull Request] [eip7805: rebase FOCIL onto Gloas](https://github.com/ethereum/consensus-specs/pull/4714) - 2025-10-30
+* [Pull Request] [eip7732: clarify PTC description](https://github.com/ethereum/consensus-specs/pull/4719) - 2025-11-02
+* [Pull Request] [Clarify the `SignedExecutionPayloadEnvelope` construction section](https://github.com/ethereum/consensus-specs/pull/4734) - 2025-11-09
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Update EIP-7805: reflect the latest engine APIs spec change](https://github.com/ethereum/EIPs/pull/10492) - 2025-10-08
 
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [Update EIP-7928: Update `CodeData` to use `Bytecode`](https://github.com/ethereum/EIPs/pull/10921) - 2025-12-15
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [FOCIL Breakout #22, October 21, 2025](https://github.com/ethereum/pm/issues/1774) - 2025-10-21
 * [Issue] [FOCIL Breakout #23, November 4, 2025](https://github.com/ethereum/pm/issues/1793) - 2025-11-04

--- a/members/jimmygchen.md
+++ b/members/jimmygchen.md
@@ -12,18 +12,18 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Ajimm
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [Delete attester cache](https://github.com/sigp/lighthouse/pull/8469) - 2026-01-06
 * [Issue] [Re-introduce clearer variable names in beacon processor work queue](https://github.com/sigp/lighthouse/issues/8648) - 2026-01-12
 * [Issue] [Implement partial data columns metrics](https://github.com/sigp/lighthouse/issues/8654) - 2026-01-13
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Updated consensus types for Gloas `1.7.0-alpha.1`](https://github.com/sigp/lighthouse/pull/8688) - 2026-01-21
 * [Issue] [Implement updated `update_proposer_boost_root` in fork choice](https://github.com/sigp/lighthouse/issues/8689) - 2026-01-21
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [Release v8.1.0](https://github.com/sigp/lighthouse/pull/8749) - 2026-02-04
 * [Issue] [Head monitor service resilience improvements](https://github.com/sigp/lighthouse/issues/8741) - 2026-02-04
 * [Issue] [Implement inactivity_scores reward EF tests from v1.7.0-alpha.2](https://github.com/sigp/lighthouse/issues/8750) - 2026-02-04
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [Fix duplicate column reconstruction at deadline](https://github.com/sigp/lighthouse/pull/8855) - 2026-02-18
+* [Pull Request] [Add debug spans to DB write paths](https://github.com/sigp/lighthouse/pull/8895) - 2026-02-24
 * [Issue] [Add missing SSZ response support to several HTTP API endpoints](https://github.com/sigp/lighthouse/issues/8892) - 2026-02-24
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [Update yanked keccak 0.1.5 to 0.1.6](https://github.com/sigp/lighthouse/pull/8900) - 2026-02-25
 * [Issue] [Gloas: send early payload envelopes to reprocess queue](https://github.com/sigp/lighthouse/issues/8922) - 2026-03-02
 * [Issue] [Gloas: envelope peer penalties and REJECT/IGNORE mapping](https://github.com/sigp/lighthouse/issues/8949) - 2026-03-09
 * [Issue] [Gloas: envelope deduplication and status tracking](https://github.com/sigp/lighthouse/issues/8948) - 2026-03-09
@@ -38,29 +38,29 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Ajimm
 * [Pull Request] [Fix duplicate fields being logged when the field exists in both the span and the event](https://github.com/sigp/lighthouse/pull/8183) - 2025-10-09
 * [Pull Request] [Release v8.0.0-rc.1](https://github.com/sigp/lighthouse/pull/8185) - 2025-10-10
 
-* [Pull Request] []() - 2025-10-16
+* [Pull Request] [Fix `get_header` JSON deserialization.](https://github.com/sigp/lighthouse/pull/8228) - 2025-10-16
 * [Issue] [v8.0.0 release testing checklist](https://github.com/sigp/lighthouse/issues/8233) - 2025-10-17
-* [Pull Request] []() - 2025-10-17
+* [Pull Request] [Feature gate test CLI flags](https://github.com/sigp/lighthouse/pull/8231) - 2025-10-17
 * [Issue] [Test improvement tracking issue](https://github.com/sigp/lighthouse/issues/8248) - 2025-10-20
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [Trigger backfill on startup if user switches to a supernode or semi-supernode](https://github.com/sigp/lighthouse/pull/8265) - 2025-10-22
 * [Issue] [Reduce unnecessary data column downloads during backfill for full nodes](https://github.com/sigp/lighthouse/issues/8308) - 2025-10-28
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-11-05
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-19
+* [Pull Request] [Bump gas limit to 60M](https://github.com/sigp/lighthouse/pull/8331) - 2025-10-30
+* [Pull Request] [Download execution engine release binaries instead of building locally on CI](https://github.com/sigp/lighthouse/pull/8370) - 2025-11-05
+* [Pull Request] [Fix custody context initialization race condition that caused panic](https://github.com/sigp/lighthouse/pull/8391) - 2025-11-10
+* [Pull Request] [Fix md format](https://github.com/sigp/lighthouse/pull/8434) - 2025-11-19
 * [Issue] [Reduce validator client proposer duties polling with Fulu proposer lookahead](https://github.com/sigp/lighthouse/issues/8457) - 2025-11-25
-* [Pull Request] []() - 2025-11-24
-* [Pull Request] []() - 2025-11-25
+* [Pull Request] [Optimise pubkey cache initialisation during beacon node startup ](https://github.com/sigp/lighthouse/pull/8451) - 2025-11-24
+* [Pull Request] [Optimize AttesterCache::maybe_cache_state to reduce lock contention](https://github.com/sigp/lighthouse/pull/8463) - 2025-11-25
 * [Issue] [Separate async and blocking task counters in beacon processor](https://github.com/sigp/lighthouse/issues/8460) - 2025-11-25
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-11-27
+* [Pull Request] [Add tests for  checkpoint sync no blobs](https://github.com/sigp/lighthouse/pull/8473) - 2025-11-26
+* [Pull Request] [Add tracing spans to validator client duty cycles](https://github.com/sigp/lighthouse/pull/8482) - 2025-11-27
 * [Issue] [BLS: Fix `is_infinity` flag when aggregating onto empty AggregateSignature](https://github.com/sigp/lighthouse/issues/8491) - 2025-11-28
 * [Issue] [Fix TOCTOU bug in unused_port module](https://github.com/sigp/lighthouse/issues/8490) - 2025-11-28
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-01
-* [Pull Request] []() - 2025-12-05
+* [Pull Request] [Update local testnet scripts for the fulu fork](https://github.com/sigp/lighthouse/pull/8489) - 2025-11-28
+* [Pull Request] [Instrument attestation signing.](https://github.com/sigp/lighthouse/pull/8508) - 2025-12-01
+* [Pull Request] [Move beacon pool http api to its own separate module](https://github.com/sigp/lighthouse/pull/8543) - 2025-12-05
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [Only require nodes to publish custody columns from reconstruction](https://github.com/ethereum/consensus-specs/pull/4657) - 2025-10-15
 
 [ethpandaops/assertoor](https://github.com/ethpandaops/assertoor)
 * [Issue] [Flaky blob transaction test](https://github.com/ethpandaops/assertoor/issues/125) - 2025-10-29

--- a/members/jklondon.md
+++ b/members/jklondon.md
@@ -12,10 +12,11 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-11
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [mcp server prototype [MVP]](https://github.com/erigontech/erigon/pull/18623) - 2026-01-11
+* [Pull Request] [fix idx versioning](https://github.com/erigontech/erigon/pull/18699) - 2026-01-16
+* [Pull Request] [StorageRange Fix](https://github.com/erigontech/erigon/pull/19149) - 2026-02-12
+* [Pull Request] [[kimiko] Analyze all commits that were pushed to the current branch (in](https://github.com/erigontech/erigon/pull/19653) - 2026-03-05
+* [Commit] [[kimiko] cl/sentinel: fix peerstore data race in concurrent peer connections (#19603)  (#19616)](https://github.com/erigontech/erigon/commit/2d94e91a23edfdad4b76aa393c0cdca3eb255762) - 2026-03-10
 ## Q4 2025
 
 
@@ -29,15 +30,15 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Commit] [commit](https://github.com/erigontech/erigon/commit/1f14df85d15e65cdf843842c6d37acbb34bd2c5f) - 2025-10-09
 * [Issue] [question about updating to mdbx 0.39.10 (0.13.8)](https://github.com/erigontech/erigon/issues/17419) - 2025-10-10
 * [Issue] [rewrite PR with ContractRef but with green CI](https://github.com/erigontech/erigon/issues/17491) - 2025-10-15
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-10-21
-* [Pull Request] []() - 2025-10-22
-* [Pull Request] []() - 2025-11-01
+* [Pull Request] [adding doc to version type + renamed inner version to logicVersion (explained)](https://github.com/erigontech/erigon/pull/17490) - 2025-10-15
+* [Pull Request] [[r3.2] mdbx 0.13.7 with small fix](https://github.com/erigontech/erigon/pull/17574) - 2025-10-21
+* [Pull Request] [more logs and versioning support to block tx index](https://github.com/erigontech/erigon/pull/17602) - 2025-10-22
+* [Pull Request] [mdbx 0.13.9](https://github.com/erigontech/erigon/pull/17743) - 2025-11-01
 * [Issue] [To gen and release files - on 3.4 snapshotters](https://github.com/erigontech/erigon/issues/17877) - 2025-11-13
-* [Pull Request] []() - 2025-11-14
-* [Pull Request] []() - 2025-11-15
-* [Pull Request] []() - 2025-11-22
-* [Pull Request] []() - 2025-12-12
+* [Pull Request] [clarification of db version err text](https://github.com/erigontech/erigon/pull/17904) - 2025-11-14
+* [Pull Request] [unit tests + small parsing unification](https://github.com/erigontech/erigon/pull/17915) - 2025-11-15
+* [Pull Request] [env var to eradicate time from logs (for systemctl logs for ex)](https://github.com/erigontech/erigon/pull/18022) - 2025-11-22
+* [Pull Request] [[r3.3] Caplin: to not use `type` field #18279](https://github.com/erigontech/erigon/pull/18280) - 2025-12-12
 * [Pull Request] []() - 2025-12-19
 ## Q3 2025
 

--- a/members/jochem-brouwer.md
+++ b/members/jochem-brouwer.md
@@ -12,14 +12,14 @@ Team: [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-
 
 
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [[DRAFT] Convert EELS tests to gas-benchmarks format on a stateful network](https://github.com/NethermindEth/gas-benchmarks/pull/95) - 2026-01-06
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Account(storage={}) infinite loop-checks account storage over RPC](https://github.com/ethereum/execution-specs/issues/2162) - 2026-02-09
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [feat(tests): add hash chain test to test parallel execution benchs](https://github.com/ethereum/execution-specs/pull/2197) - 2026-02-12
+* [Pull Request] [feat(stubs): target contract](https://github.com/ethereum/execution-specs/pull/2357) - 2026-02-27
+* [Pull Request] [fix(benchmarks): move account_query test from compute to stateful](https://github.com/ethereum/execution-specs/pull/2409) - 2026-03-04
+* [Pull Request] [fix(benchmarks): fix fill issues with mint/approve erc20 updates](https://github.com/ethereum/execution-specs/pull/2413) - 2026-03-05
 * [Issue] [Replace temporary gas-repricings specific benchmarks by more general ones](https://github.com/ethereum/execution-specs/issues/2411) - 2026-03-04
 * [Issue] [Existing contracts deployed via deterministic CREATE2 factory are still being deployed](https://github.com/ethereum/execution-specs/issues/2436) - 2026-03-06
 ## Q4 2025
@@ -42,16 +42,16 @@ Team: [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-
 * [Issue] [Using `uv run execute remote` with --engine-endpoint should not require `--rpc-seed-key` and should auto-fund EOA root via PayloadAttributes.withdrawals](https://github.com/ethereum/execution-specs/issues/1620) - 2025-10-16
 * [Issue] [Using `uv run execute remote` with `--rpc-endpoint` requires `--chain-id`, while it should not](https://github.com/ethereum/execution-specs/issues/1619) - 2025-10-16
 * [Issue] [Feature request: read results of the generated blocks/txs](https://github.com/ethereum/execution-specs/issues/1618) - 2025-10-16
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-15
+* [Pull Request] [feat(tests): add XEN tests](https://github.com/ethereum/execution-specs/pull/1766) - 2025-11-07
+* [Pull Request] [feat(tests): add gas-repricings SLOAD tests](https://github.com/ethereum/execution-specs/pull/1769) - 2025-11-10
+* [Pull Request] [feat(tests): add more sload/sstore combos](https://github.com/ethereum/execution-specs/pull/1794) - 2025-11-15
 
-* [Pull Request] []() - 2025-12-04
+* [Pull Request] [feat(benchmarks): add keccak benchmark with updated memory](https://github.com/ethereum/execution-specs/pull/1849) - 2025-12-04
 * [Issue] [Benchmarks: implement non-parallelizable benchmarks for split transactions](https://github.com/ethereum/execution-specs/issues/1881) - 2025-12-10
-* [Pull Request] []() - 2025-12-16
+* [Pull Request] [feat(tests): add 7702 auth chain id 0x00 test (invalid)](https://github.com/ethereum/execution-specs/pull/1905) - 2025-12-16
 [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo)
-* [Pull Request] []() - 2025-11-17
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [EVM: ensure codeAddress in step event is correctly set](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4189) - 2025-11-17
+* [Pull Request] [EIP-7702: unpad bytes in case of hex-string "0x0" inputs for authorization list fields](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4209) - 2025-12-17
 * [Pull Request] []() - 2025-12-24
 ## Q3 2025
 

--- a/members/joshdavislight.md
+++ b/members/joshdavislight.md
@@ -10,4 +10,4 @@ Github: [@joshdavislight](https://github.com/joshdavislight)
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-19
+* [Pull Request] [Update EIP-7773: CFI/DFI as per ACDE 229](https://github.com/ethereum/EIPs/pull/11213) - 2026-02-19

--- a/members/jsign.md
+++ b/members/jsign.md
@@ -16,6 +16,7 @@ Team: [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%
 * [Issue] [Consider an optional flag to collect and dump GPU metrics](https://github.com/eth-act/ere/issues/265) - 2026-01-06
 
 * [Pull Request] [Add zisk cycle scope tracker](https://github.com/eth-act/ere/pull/287) - 2026-02-06
+* [Review] [Review on: Remove some zkVMs](https://github.com/eth-act/ere/pull/307#pullrequestreview-3921842211) - 2026-03-10
 [bluealloy/revm](https://github.com/bluealloy/revm)
 * [Pull Request] [fix(bal): fix populated account if pre-state was none](https://github.com/bluealloy/revm/pull/3357) - 2026-01-27
 
@@ -33,6 +34,17 @@ Team: [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%
 * [Pull Request] [feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472) - 2026-03-10
 * [Pull Request] [feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469) - 2026-03-10
 * [Issue] [Guest program: should it enforce execution witness canonicality?](https://github.com/ethereum/execution-specs/issues/2474) - 2026-03-10
+* [Review] [Review on: feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472#pullrequestreview-3925757322) - 2026-03-10
+* [Review] [Review on: feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472#pullrequestreview-3925759910) - 2026-03-10
+* [Review] [Review on: feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472#pullrequestreview-3925767604) - 2026-03-10
+* [Review] [Review on: feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472#pullrequestreview-3925781575) - 2026-03-10
+* [Review] [Review on: feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472#pullrequestreview-3925788074) - 2026-03-10
+* [Review] [Review on: feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472#pullrequestreview-3925803693) - 2026-03-10
+* [Review] [Review on: feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469#pullrequestreview-3922782779) - 2026-03-10
+* [Review] [Review on: feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469#pullrequestreview-3922789214) - 2026-03-10
+* [Review] [Review on: feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469#pullrequestreview-3922802865) - 2026-03-10
+* [Review] [Review on: feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469#pullrequestreview-3922809574) - 2026-03-10
+* [Review] [Review on: feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469#pullrequestreview-3922814994) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/jsign.md
+++ b/members/jsign.md
@@ -12,21 +12,27 @@ Team: [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%
 
 
 [eth-act/ere](https://github.com/eth-act/ere)
-* [Pull Request] []() - 2026-01-04
+* [Pull Request] [dockerized: support ERE_DOCKER_NETWORK](https://github.com/eth-act/ere/pull/262) - 2026-01-04
 * [Issue] [Consider an optional flag to collect and dump GPU metrics](https://github.com/eth-act/ere/issues/265) - 2026-01-06
 
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [Add zisk cycle scope tracker](https://github.com/eth-act/ere/pull/287) - 2026-02-06
 [bluealloy/revm](https://github.com/bluealloy/revm)
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [fix(bal): fix populated account if pre-state was none](https://github.com/bluealloy/revm/pull/3357) - 2026-01-27
 
 [eth-act/zkevm-benchmark-workload](https://github.com/eth-act/zkevm-benchmark-workload)
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [Update ere-guest program dep and Reth crates](https://github.com/eth-act/zkevm-benchmark-workload/pull/252) - 2026-02-03
+* [Pull Request] [witness-generator-cli: support generating fixtures from "raw parts"](https://github.com/eth-act/zkevm-benchmark-workload/pull/254) - 2026-02-05
+* [Pull Request] [Support Zisk profiling](https://github.com/eth-act/zkevm-benchmark-workload/pull/259) - 2026-02-10
+* [Pull Request] [Add `--action verify` to decouple proof verification measurements](https://github.com/eth-act/zkevm-benchmark-workload/pull/260) - 2026-02-12
 * [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-19
+* [Pull Request] [update ere and ere-guests](https://github.com/eth-act/zkevm-benchmark-workload/pull/261) - 2026-02-17
+* [Pull Request] [Bump Rust version to fix docker image build in CI](https://github.com/eth-act/zkevm-benchmark-workload/pull/264) - 2026-02-19
+
+[ethereum/execution-specs](https://github.com/ethereum/execution-specs)
+* [Pull Request] [refactor(specs): delay get_code calls in CALL-like opcodes after gas charging and stack-depth checks](https://github.com/ethereum/execution-specs/pull/2473) - 2026-03-10
+* [Pull Request] [feat(zkevm): add test for execution witness bytecodes for contract creation, CALL-variants and empty block](https://github.com/ethereum/execution-specs/pull/2472) - 2026-03-10
+* [Pull Request] [feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469) - 2026-03-10
+* [Issue] [Guest program: should it enforce execution witness canonicality?](https://github.com/ethereum/execution-specs/issues/2474) - 2026-03-10
 ## Q4 2025
 
 
@@ -38,13 +44,13 @@ Team: [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%
 * [Issue] [OpenVM: No multi-gpu support](https://github.com/eth-act/ere/issues/242) - 2025-12-10
 * [Issue] [zisk v0.14.0: particular fixture blocks the prover](https://github.com/eth-act/ere/issues/246) - 2025-12-11
 * [Issue] [airbender: deadlocks on heavy blocks](https://github.com/eth-act/ere/issues/253) - 2025-12-19
-* [Pull Request] []() - 2025-12-29
+* [Pull Request] [Support setting how many GPUs to expose in dockerized environment](https://github.com/eth-act/ere/pull/258) - 2025-12-29
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
-* [Pull Request] []() - 2025-12-04
+* [Pull Request] [feat(tests): add Osaka fork specification to ForkSpec enum](https://github.com/paradigmxyz/reth/pull/20120) - 2025-12-04
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [feat(benchmarks): fix bytecode attack for CALL-like opcodes to work in Osaka](https://github.com/ethereum/execution-specs/pull/1850) - 2025-12-05
+* [Pull Request] [feat(benchmarks): fix benchmark for SELFDESTRUCT of created accounts for Osaka](https://github.com/ethereum/execution-specs/pull/1906) - 2025-12-11
 ## Q3 2025
 
 

--- a/members/jsign.md
+++ b/members/jsign.md
@@ -27,6 +27,9 @@ Team: [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%
 * [Pull Request] []() - 2026-02-13
 * [Pull Request] []() - 2026-02-17
 * [Pull Request] []() - 2026-02-19
+
+[ethereum/execution-specs](https://github.com/ethereum/execution-specs)
+* [Issue] [Guest program: should it enforce execution witness canonicality?](https://github.com/ethereum/execution-specs/issues/2474) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/jtraglia.md
+++ b/members/jtraglia.md
@@ -12,52 +12,52 @@ Team: [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844/pulls?q=is%3A
 
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-10
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-17
+* [Pull Request] [Bump version to 1.7.0-alpha.0](https://github.com/ethereum/consensus-specs/pull/4811) - 2026-01-05
+* [Pull Request] [Update release trigger](https://github.com/ethereum/consensus-specs/pull/4825) - 2026-01-09
+* [Pull Request] [Improve the release action](https://github.com/ethereum/consensus-specs/pull/4827) - 2026-01-10
+* [Pull Request] [Fix indexed payload attestation domain](https://github.com/ethereum/consensus-specs/pull/4836) - 2026-01-13
+* [Pull Request] [Rename two sections](https://github.com/ethereum/consensus-specs/pull/4844) - 2026-01-16
+* [Pull Request] [Enable two more pypy checks](https://github.com/ethereum/consensus-specs/pull/4845) - 2026-01-17
 * [Issue] [Release: `v1.7.0-alpha.2`](https://github.com/ethereum/consensus-specs/issues/4858) - 2026-01-23
 
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-02
+* [Pull Request] [Simplify data column sidecar gossip checks in Gloas](https://github.com/ethereum/consensus-specs/pull/4874) - 2026-01-28
+* [Pull Request] [Fix assertion checks in tests](https://github.com/ethereum/consensus-specs/pull/4889) - 2026-01-31
+* [Pull Request] [Add an `AGENTS.md` file](https://github.com/ethereum/consensus-specs/pull/4894) - 2026-02-02
 * [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [Add executable gossip validation functions for phase0](https://github.com/ethereum/consensus-specs/pull/4902) - 2026-02-06
+* [Pull Request] [Fix test which incorrectly assumes min builder balance is 32 ETH](https://github.com/ethereum/consensus-specs/pull/4909) - 2026-02-09
+* [Pull Request] [Enable tests for EIP-8025](https://github.com/ethereum/consensus-specs/pull/4911) - 2026-02-10
 * [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-14
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [Refactor builder deposit conditions in `process_deposit_request`](https://github.com/ethereum/consensus-specs/pull/4916) - 2026-02-12
+* [Pull Request] [Use ckzg by default for tests](https://github.com/ethereum/consensus-specs/pull/4921) - 2026-02-14
+* [Pull Request] [Generate specs before publishing](https://github.com/ethereum/consensus-specs/pull/4938) - 2026-02-18
+* [Pull Request] [Fix inclusion list test for mainnet](https://github.com/ethereum/consensus-specs/pull/4945) - 2026-02-23
+* [Pull Request] [Update fork choice store to use milliseconds](https://github.com/ethereum/consensus-specs/pull/4954) - 2026-03-02
+* [Pull Request] [Use xdist worksteal distribution method for tests](https://github.com/ethereum/consensus-specs/pull/4961) - 2026-03-03
+* [Pull Request] [Ignore hidden files when running mdformat](https://github.com/ethereum/consensus-specs/pull/4978) - 2026-03-05
 * [Issue] [Look into uploading non-zipped nightly reference tests](https://github.com/ethereum/consensus-specs/issues/4975) - 2026-03-05
-* [Pull Request] []() - 2026-03-06
-* [Pull Request] []() - 2026-03-07
-* [Pull Request] []() - 2026-03-10
+* [Pull Request] [Improve pytest performance](https://github.com/ethereum/consensus-specs/pull/4987) - 2026-03-06
+* [Pull Request] [Fix sampling config test](https://github.com/ethereum/consensus-specs/pull/4988) - 2026-03-07
+* [Pull Request] [Add support for python 3.14](https://github.com/ethereum/consensus-specs/pull/4995) - 2026-03-10
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [feat: enable specref features & remove unnecessary spec items](https://github.com/ChainSafe/lodestar/pull/8788) - 2026-01-27
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [Improve ethspecify integration](https://github.com/OffchainLabs/prysm/pull/16304) - 2026-01-29
 
 [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844)
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [Update trusted setup URL to use master branch](https://github.com/ethereum/c-kzg-4844/pull/623) - 2026-02-01
+* [Pull Request] [Bump clang-format to v21](https://github.com/ethereum/c-kzg-4844/pull/634) - 2026-02-24
+* [Pull Request] [Allow compiler overrides & only use some flags for clang](https://github.com/ethereum/c-kzg-4844/pull/633) - 2026-02-25
+* [Pull Request] [Drop support for macOS x86 in python package workflow](https://github.com/ethereum/c-kzg-4844/pull/635) - 2026-02-26
 ## Q4 2025
 
 
 [consensys/teku](https://github.com/consensys/teku)
 * [Pull Request] [Trim trailing whitespace to fix specrefs CI check](https://github.com/Consensys/teku/pull/9954) - 2025-10-01
 
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-12-03
+* [Pull Request] [Clean up Gloas upgrade function](https://github.com/Consensys/teku/pull/10116) - 2025-11-10
+* [Pull Request] [Run `kzg.loadTrustedSetup` in thread with 8MB stack size](https://github.com/Consensys/teku/pull/10197) - 2025-12-03
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Commit] [Fix weak subjectivity checkpoint check (#4620)](https://github.com/ethereum/consensus-specs/commit/4f743484b404c42988194a7160f2f532d69cc2d0) - 2025-10-01
 * [Commit] [Use non-editable installs for test generators (#4634)](https://github.com/ethereum/consensus-specs/commit/5a4e05a29694576b036c2ad0f8d19bf5daed0788) - 2025-10-03
@@ -65,15 +65,15 @@ Team: [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844/pulls?q=is%3A
 * [Pull Request] [Restrict python version to <3.14](https://github.com/ethereum/consensus-specs/pull/4643) - 2025-10-07
 * [Commit] [Restrict python version to <3.14 (#4643)](https://github.com/ethereum/consensus-specs/commit/44db4a3aa18db12a16b09f4b808b656427825974) - 2025-10-08
 
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [Set fork epoch & blob schedule for Fulu](https://github.com/ethereum/consensus-specs/pull/4689) - 2025-10-22
 * [Issue] [Remove support for former deposit mechanism](https://github.com/ethereum/consensus-specs/issues/4686) - 2025-10-22
 * [Issue] [Fix tests so that merge functions do not need to be modified](https://github.com/ethereum/consensus-specs/issues/4684) - 2025-10-22
-* [Pull Request] []() - 2025-10-23
+* [Pull Request] [Clean up Gloas specs (part 3)](https://github.com/ethereum/consensus-specs/pull/4694) - 2025-10-23
 * [Issue] [Test generator blocking issue](https://github.com/ethereum/consensus-specs/issues/4710) - 2025-10-29
 * [Issue] [An internal research client](https://github.com/ethereum/consensus-specs/issues/4749) - 2025-11-19
 * [Issue] [Publish eth2spec package again](https://github.com/ethereum/consensus-specs/issues/4748) - 2025-11-19
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [Fix various nits](https://github.com/ethereum/consensus-specs/pull/4771) - 2025-12-02
+* [Pull Request] [Add `is_higher_value_bid` helper for bid forwarding threshold](https://github.com/ethereum/consensus-specs/pull/4792) - 2025-12-15
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [EIP-7732 Breakout Room Call #26, October 24, 2025](https://github.com/ethereum/pm/issues/1759) - 2025-10-13
 * [Issue] [EIP-7732 Breakout Room Call #27, November 7, 2025](https://github.com/ethereum/pm/issues/1783) - 2025-10-25
@@ -81,7 +81,7 @@ Team: [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844/pulls?q=is%3A
 * [Issue] [EIP-7732 Breakout Room Call #29, December 19, 2025](https://github.com/ethereum/pm/issues/1835) - 2025-12-05
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2025-12-06
+* [Pull Request] [Add spec references, a mapping of spec to implementation](https://github.com/sigp/lighthouse/pull/8549) - 2025-12-06
 ## Q3 2025
 
 

--- a/members/jwasinger.md
+++ b/members/jwasinger.md
@@ -18,6 +18,7 @@ Team: Geth
 * [Issue] [Use blockchain tests to add coverage for the miner](https://github.com/ethereum/go-ethereum/issues/33762) - 2026-02-04
 * [Pull Request] []() - 2026-02-04
 * [Pull Request] []() - 2026-03-02
+* [Pull Request] []() - 2026-03-10
 ## Q4 2025
 
 

--- a/members/jwasinger.md
+++ b/members/jwasinger.md
@@ -12,23 +12,24 @@ Team: Geth
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-08
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-22
+* [Pull Request] [Po/par exe nblocks](https://github.com/ethereum/go-ethereum/pull/33552) - 2026-01-08
+* [Pull Request] [core/vm: in selfdestruct gas calculation, return early if there isn't enough gas to cover cold account access costs](https://github.com/ethereum/go-ethereum/pull/33450) - 2026-01-16
+* [Pull Request] [EIP 7928 - Block Access Lists](https://github.com/ethereum/go-ethereum/pull/33660) - 2026-01-22
 * [Issue] [Use blockchain tests to add coverage for the miner](https://github.com/ethereum/go-ethereum/issues/33762) - 2026-02-04
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [fix eip-7778 in the miner and BAL parallel state processor](https://github.com/ethereum/go-ethereum/pull/33761) - 2026-02-04
+* [Pull Request] [all: devnet 3](https://github.com/ethereum/go-ethereum/pull/33930) - 2026-03-02
+* [Pull Request] [core,miner: clean up miner and BAL config changes](https://github.com/ethereum/go-ethereum/pull/33983) - 2026-03-10
 ## Q4 2025
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
 * [Pull Request] [all: block access list execution and generation (tracer-based approach for BAL generation/validation)](https://github.com/ethereum/go-ethereum/pull/32840) - 2025-10-05
 * [Pull Request] [all: block access list execution and generation (tracer-based approach for BAL generation/validation)](https://github.com/ethereum/go-ethereum/pull/32865) - 2025-10-09
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-10-21
-* [Pull Request] []() - 2025-10-25
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-12-09
+* [Pull Request] [core: invoke selfdestruct tracer hooks during finalisation](https://github.com/ethereum/go-ethereum/pull/32919) - 2025-10-15
+* [Pull Request] [core: introduce new tracing hooks prior to transaction execution and after block reward application](https://github.com/ethereum/go-ethereum/pull/32985) - 2025-10-21
+* [Pull Request] [core/state, trie: improve parallelization of account and storage trie hashing](https://github.com/ethereum/go-ethereum/pull/33022) - 2025-10-25
+* [Pull Request] [core/vm: check if read-only in gas handlers](https://github.com/ethereum/go-ethereum/pull/33281) - 2025-11-26
+* [Pull Request] [tests: integrate BlockTest.run into BlockTest.Run](https://github.com/ethereum/go-ethereum/pull/33383) - 2025-12-09
 * [Pull Request] []() - 2025-12-10
 * [Pull Request] []() - 2025-12-18
 ## Q3 2025

--- a/members/jxs.md
+++ b/members/jxs.md
@@ -12,7 +12,7 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Ajxs)
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2025-11-18
+* [Pull Request] [improve disconnect logging on rpc](https://github.com/sigp/lighthouse/pull/8429) - 2025-11-18
 ## Q2 2025
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)

--- a/members/kamilchodola.md
+++ b/members/kamilchodola.md
@@ -12,19 +12,19 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [Merge master](https://github.com/NethermindEth/nethermind/pull/10422) - 2026-02-06
+* [Pull Request] [Fix Kute Windows performance: disable proxy detection, fix file check](https://github.com/NethermindEth/nethermind/pull/10491) - 2026-02-11
 
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Resolve merge conflict with master](https://github.com/NethermindEth/nethermind/pull/10595) - 2026-02-20
+* [Pull Request] [Warmup improvement](https://github.com/NethermindEth/nethermind/pull/10652) - 2026-02-25
+* [Pull Request] [perf: reduce ThreadPool contention from pruning and prewarmer](https://github.com/NethermindEth/nethermind/pull/10662) - 2026-02-26
+* [Pull Request] [refactor: remove NethermindConstructorFinder, use explicit factory registrations](https://github.com/NethermindEth/nethermind/pull/10745) - 2026-03-09
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-22
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [Improve generator workflow](https://github.com/NethermindEth/gas-benchmarks/pull/115) - 2026-02-10
+* [Pull Request] [Fix report generation bugs and add run_and_post_metrics options](https://github.com/NethermindEth/gas-benchmarks/pull/120) - 2026-02-18
+* [Pull Request] [Chore/repricing dedicated runners](https://github.com/NethermindEth/gas-benchmarks/pull/124) - 2026-02-22
+* [Pull Request] [Fix/report generation bugs](https://github.com/NethermindEth/gas-benchmarks/pull/125) - 2026-02-23
+* [Pull Request] [fix: init execution-specs submodules after clone/pull](https://github.com/NethermindEth/gas-benchmarks/pull/130) - 2026-02-27
 ## Q4 2025
 
 
@@ -34,7 +34,7 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
 * [Pull Request] [Refactor RPC comparison workflow for clarity and efficiency](https://github.com/NethermindEth/nethermind/pull/9418) - 2025-10-06
 
-* [Pull Request] []() - 2025-11-14
+* [Pull Request] [Merge master into blockbuilder force getPayload method](https://github.com/NethermindEth/nethermind/pull/9708) - 2025-11-14
 * [Pull Request] []() - 2025-12-15
 [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests)
 * [Pull Request] [feat: Implement configurable poll interval for transactions](https://github.com/ethereum/execution-spec-tests/pull/2286) - 2025-10-09

--- a/members/kasey.md
+++ b/members/kasey.md
@@ -12,7 +12,7 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Akasey)
 
 
 [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844)
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [benchmark measuring proof verification with different numbers of cells](https://github.com/ethereum/c-kzg-4844/pull/624) - 2026-02-12
 ## Q4 2025
 
 
@@ -36,8 +36,8 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Akasey)
 * [Commit] [Github CI: Update runs-on to ubuntu-4 (#15778)](https://github.com/OffchainLabs/prysm/commit/1432867c9228207a8e9badc2c7b3f62a23a5f6b1) - 2025-10-07
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-29
+* [Pull Request] [Backfill data columns](https://github.com/OffchainLabs/prysm/pull/15580) - 2025-12-02
+* [Pull Request] [Fix validation bug in --backfill-oldest-slot](https://github.com/OffchainLabs/prysm/pull/16173) - 2025-12-29
 ## Q3 2025
 
 

--- a/members/kdeme.md
+++ b/members/kdeme.md
@@ -12,29 +12,29 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Add nimbus_portal_client binary to the release procedure](https://github.com/status-im/nimbus-eth1/pull/3923) - 2026-01-19
+* [Pull Request] [Uncomment & rework debug json-rpc endpoints](https://github.com/status-im/nimbus-eth1/pull/3929) - 2026-01-21
 
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [Fix JSON error object for eth_estimateGas](https://github.com/status-im/nimbus-eth1/pull/3940) - 2026-01-29
 * [Issue] [Improve eth_estimateGas binary search by doing first some short circuits](https://github.com/status-im/nimbus-eth1/issues/3946) - 2026-01-30
 * [Issue] [Fix EstimateGas to add gas cost for EIP-7702  authorization](https://github.com/status-im/nimbus-eth1/issues/3945) - 2026-01-30
 * [Issue] [Implement Execution api method eth_feeHistory](https://github.com/status-im/nimbus-eth1/issues/3944) - 2026-01-30
 * [Issue] [Implement Execution api method eth_simulateV1](https://github.com/status-im/nimbus-eth1/issues/3943) - 2026-01-30
 * [Issue] [Execution-api JSON-RPC master tracker issue](https://github.com/status-im/nimbus-eth1/issues/3942) - 2026-01-30
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [EraE implementation WIP](https://github.com/status-im/nimbus-eth1/pull/3979) - 2026-02-12
 * [Issue] [Execution API: block tag not parsing hash](https://github.com/status-im/nimbus-eth1/issues/3981) - 2026-02-15
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-01-23
+* [Pull Request] [Bump nim-web3 and related changes](https://github.com/status-im/nimbus-eth2/pull/7876) - 2026-01-23
 * [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-14
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [Use toExecutionPayloadHeader consistently in process_execution_payload](https://github.com/status-im/nimbus-eth2/pull/7965) - 2026-02-14
+* [Pull Request] [EIP8025: Start of implementation](https://github.com/status-im/nimbus-eth2/pull/8004) - 2026-02-20
 ## Q4 2025
 
 
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
 * [Pull Request] [Docs: Use consensus light client naming throughout the guide](https://github.com/status-im/nimbus-eth2/pull/7560) - 2025-10-01
 
-* [Pull Request] []() - 2025-12-04
+* [Pull Request] [Deprecate --in-process-validators flag and rm related leftovers](https://github.com/status-im/nimbus-eth2/pull/7777) - 2025-12-04
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
 * [Pull Request] [Portal + era1: Remove use of hardcoded mainnet mergeBlockNumber](https://github.com/status-im/nimbus-eth1/pull/3742) - 2025-10-03
 * [Commit] [Portal + era1: Remove use of hardcoded mainnet mergeBlockNumber](https://github.com/status-im/nimbus-eth1/commit/ad51effc74c091db846371311655aaeeb6c471e1) - 2025-10-03
@@ -49,18 +49,18 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Issue] [Experiment with a RangeFindContent message type in Portal wire protocol](https://github.com/status-im/nimbus-eth1/issues/3773) - 2025-10-16
 * [Issue] [Offer data or subset of data before it gets pruned](https://github.com/status-im/nimbus-eth1/issues/3775) - 2025-10-17
 * [Issue] [Add block receipts retrieval from Portal in EL](https://github.com/status-im/nimbus-eth1/issues/3774) - 2025-10-17
-* [Pull Request] []() - 2025-10-24
+* [Pull Request] [Fix ForkId compatible bug](https://github.com/status-im/nimbus-eth1/pull/3796) - 2025-10-24
 * [Issue] [Missing eip-2124 / EIP-6122 testing for fork combination possibilities](https://github.com/status-im/nimbus-eth1/issues/3795) - 2025-10-24
 * [Issue] [Invalid forkid checking for discv5 eligibleNode check](https://github.com/status-im/nimbus-eth1/issues/3794) - 2025-10-24
-* [Pull Request] []() - 2025-10-28
-* [Pull Request] []() - 2025-10-31
-* [Pull Request] []() - 2025-11-04
+* [Pull Request] [EL: Small p2p connect/lookup cleanup](https://github.com/status-im/nimbus-eth1/pull/3800) - 2025-10-28
+* [Pull Request] [Fix forkId compatibility according to EIP-2124 and EIP-6122](https://github.com/status-im/nimbus-eth1/pull/3803) - 2025-10-31
+* [Pull Request] [Rework ForkId to get rid of ChainForkId and its conversions](https://github.com/status-im/nimbus-eth1/pull/3810) - 2025-11-04
 * [Issue] [Add ForkId compatibility check at eth68/69 Status message receival](https://github.com/status-im/nimbus-eth1/issues/3813) - 2025-11-05
-* [Pull Request] []() - 2025-11-05
-* [Pull Request] []() - 2025-11-06
+* [Pull Request] [Fix EthTime only forkId func to fix eth_config JSON-RPC method](https://github.com/status-im/nimbus-eth1/pull/3812) - 2025-11-05
+* [Pull Request] [Remove old Nimbus documentation](https://github.com/status-im/nimbus-eth1/pull/3816) - 2025-11-06
 * [Issue] [nec_sync_peers / buddy.ctx.pool.nBuddies value much higher than amount of rlpx peers connected](https://github.com/status-im/nimbus-eth1/issues/3823) - 2025-11-10
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [Portal: Cleanup JSON-RPC InvalidRequest usage](https://github.com/status-im/nimbus-eth1/pull/3858) - 2025-12-03
+* [Pull Request] [Adjust for optional totalDifficulty in JSON-RPC BlockObject](https://github.com/status-im/nimbus-eth1/pull/3883) - 2025-12-18
 * [Pull Request] []() - 2025-12-22
 ## Q3 2025
 

--- a/members/kevaundray.md
+++ b/members/kevaundray.md
@@ -43,6 +43,7 @@ Team: Consensus R&D (EF)
 * [Issue] [Consider separating stateless components from `Block`](https://github.com/ethereum/execution-specs/issues/2441) - 2026-03-06
 * [Issue] [Unused public key parameter in stateless code](https://github.com/ethereum/execution-specs/issues/2448) - 2026-03-09
 * [Pull Request] [chore(do not merge): evmification](https://github.com/ethereum/execution-specs/pull/2471) - 2026-03-10
+* [Review] [Review on: feat(zkevm): Add execution witness bytecode assertions and mutation support](https://github.com/ethereum/execution-specs/pull/2469#pullrequestreview-3923637143) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Add EIP: Block-in-Blobs (BiB)](https://github.com/ethereum/EIPs/pull/11212) - 2026-01-29
 

--- a/members/kevaundray.md
+++ b/members/kevaundray.md
@@ -12,12 +12,12 @@ Team: Consensus R&D (EF)
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2026-01-05
+* [Pull Request] [perf: remove allocations from merkle tree proof verification logic](https://github.com/sigp/lighthouse/pull/8614) - 2026-01-05
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Issue] [Change the public input for optional proofs from block hash to payload header](https://github.com/ethereum/consensus-specs/issues/4820) - 2026-01-08
 
-* [Pull Request] []() - 2026-01-31
+* [Pull Request] [Check for active validators in whitelist](https://github.com/ethereum/consensus-specs/pull/4886) - 2026-01-31
 * [Issue] [Unresolved TODOs from PR #4828](https://github.com/ethereum/consensus-specs/issues/4885) - 2026-01-31
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
 * [Issue] [engine_newPayloadWithWitness](https://github.com/ethereum/execution-apis/issues/741) - 2026-01-20
@@ -29,21 +29,22 @@ Team: Consensus R&D (EF)
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Consider extending specs to engine api methods](https://github.com/ethereum/execution-specs/issues/2096) - 2026-01-29
 
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-02-21
+* [Pull Request] [small ci cleanup](https://github.com/ethereum/execution-specs/pull/2217) - 2026-02-15
+* [Pull Request] [chore(do not merge): Experiment with caching for "Build Doc" Job](https://github.com/ethereum/execution-specs/pull/2271) - 2026-02-21
 * [Issue] [Question on `set_environment` in blockchain.py](https://github.com/ethereum/execution-specs/issues/2262) - 2026-02-20
 * [Issue] [Make the testing framework and EELS share the PreState thus simplifying the T8N tool](https://github.com/ethereum/execution-specs/issues/2273) - 2026-02-22
 * [Issue] [Add code_reads into state tracker](https://github.com/ethereum/execution-specs/issues/2272) - 2026-02-22
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [chore(do not merge): Experiment on `docc`](https://github.com/ethereum/execution-specs/pull/2296) - 2026-02-23
 * [Issue] [Tracking Issue: Using common types across all forks](https://github.com/ethereum/execution-specs/issues/2293) - 2026-02-23
 * [Issue] [Add `BLOCKHASH` tracking into state tracker](https://github.com/ethereum/execution-specs/issues/2279) - 2026-02-23
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-28
-* [Pull Request] []() - 2026-03-01
+* [Pull Request] [chore(do not merge): Investigate bigmem](https://github.com/ethereum/execution-specs/pull/2313) - 2026-02-25
+* [Pull Request] [chore(do not merge): Check performance with python 3.14t](https://github.com/ethereum/execution-specs/pull/2367) - 2026-02-28
+* [Pull Request] [chore: cache repeated calls to `git rev-parse HEAD` on a test run](https://github.com/ethereum/execution-specs/pull/2377) - 2026-03-01
 * [Issue] [Consider separating stateless components from `Block`](https://github.com/ethereum/execution-specs/issues/2441) - 2026-03-06
 * [Issue] [Unused public key parameter in stateless code](https://github.com/ethereum/execution-specs/issues/2448) - 2026-03-09
+* [Pull Request] [chore(do not merge): evmification](https://github.com/ethereum/execution-specs/pull/2471) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [Add EIP: Block-in-Blobs (BiB)](https://github.com/ethereum/EIPs/pull/11212) - 2026-01-29
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
 * [Issue] [Consider testing stateless execution against EEST fixtures](https://github.com/NethermindEth/nethermind/issues/10749) - 2026-03-07
@@ -57,22 +58,22 @@ Team: Consensus R&D (EF)
 * [Issue] [Add kzg block hashes to the public inputs when verifying optional execution proofs](https://github.com/ethereum/consensus-specs/issues/4637) - 2025-10-06
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2025-10-14
+* [Pull Request] [Fix venue name from ADCT to ACDT](https://github.com/protocolguild/documentation/pull/443) - 2025-10-14
 
-* [Pull Request] []() - 2025-11-30
+* [Pull Request] [Fix typo in link](https://github.com/protocolguild/documentation/pull/447) - 2025-11-30
 * [Pull Request] []() - 2025-12-11
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2025-10-18
-* [Pull Request] []() - 2025-10-27
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [chore!: remove pub visibility on `OVERFLOW_LRU_CAPACITY` and `STATE_LRU_CAPACITY_NON_ZERO`](https://github.com/sigp/lighthouse/pull/8234) - 2025-10-18
+* [Pull Request] [chore: Add Dockerfile.dev for local development](https://github.com/sigp/lighthouse/pull/8295) - 2025-10-27
+* [Pull Request] [feat!: Optional execution proofs](https://github.com/sigp/lighthouse/pull/8316) - 2025-10-28
 * [Issue] [Tracking Issue: Optional Execution Proofs](https://github.com/sigp/lighthouse/issues/8327) - 2025-10-29
 
 * [Pull Request] []() - 2025-12-29
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2025-10-31
+* [Pull Request] [core/types: Return error in `ToV1` when the sidecar version is not supported](https://github.com/ethereum/go-ethereum/pull/33066) - 2025-10-31
 
 [ethpandaops/dora](https://github.com/ethpandaops/dora)
-* [Pull Request] []() - 2025-11-03
+* [Pull Request] [chore: Add changes needed for optional execution proofs](https://github.com/ethpandaops/dora/pull/515) - 2025-11-03
 
 [eth-act/ere](https://github.com/eth-act/ere)
 * [Issue] [Tracker for RV64IM-None support](https://github.com/eth-act/ere/issues/232) - 2025-11-30

--- a/members/khovratovich.md
+++ b/members/khovratovich.md
@@ -11,4 +11,4 @@ Team: Cryptography (EF)
 ## Q1 2026
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-26
+* [Pull Request] [Update Dmitry Khovratovich's project link](https://github.com/protocolguild/documentation/pull/476) - 2026-01-26

--- a/members/kkaur01.md
+++ b/members/kkaur01.md
@@ -12,7 +12,9 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu)
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [refactor: move isRevertReasonEnabled into DataStorageConfiguration](https://github.com/besu-eth/besu/pull/9858) - 2026-02-20
+* [Pull Request] [fix(metrics): prevent duplicate OTel callback registration (#9653)](https://github.com/besu-eth/besu/pull/9957) - 2026-03-10
+* [Commit] [fix(metrics): prevent duplicate OTel callback registration (#9653) (#9957)](https://github.com/besu-eth/besu/commit/2ed7ff708c24ce623b4e140f71f8c96dfd81562d) - 2026-03-10
 ## Q2 2025
 
 

--- a/members/klkvr.md
+++ b/members/klkvr.md
@@ -21,6 +21,8 @@ Team: [Reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr)
 * [Pull Request] [perf: share highest executed tx with prewarming](https://github.com/paradigmxyz/reth/pull/22621) - 2026-02-26
 * [Pull Request] [perf: prepare txenvs in parallel](https://github.com/paradigmxyz/reth/pull/22656) - 2026-02-27
 * [Pull Request] [perf: decrease sparse trie task updates batch size](https://github.com/paradigmxyz/reth/pull/22917) - 2026-03-10
+* [Review] [Review on: perf(engine): replace moka with schnellru for precompile cache and add per-precompile sizing](https://github.com/paradigmxyz/reth/pull/22900#pullrequestreview-3925063932) - 2026-03-10
+* [Review] [Review on: chore: bump reth v1.11.2](https://github.com/paradigmxyz/reth/pull/22914#pullrequestreview-3922570101) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/klkvr.md
+++ b/members/klkvr.md
@@ -12,14 +12,15 @@ Team: [Reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr)
 
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
-* [Pull Request] []() - 2026-01-20
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-23
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [fix: clear `overlay_cache` in `with_extended_hashed_state_overlay`](https://github.com/paradigmxyz/reth/pull/21233) - 2026-01-20
+* [Pull Request] [feat: allow setting custom debug block provider](https://github.com/paradigmxyz/reth/pull/21345) - 2026-01-22
+* [Pull Request] [feat(txpool): add Block associated type to TransactionValidator trait](https://github.com/paradigmxyz/reth/pull/21359) - 2026-01-23
+* [Pull Request] [fix: add more safety checks to reveals of upper subtrie nodes](https://github.com/paradigmxyz/reth/pull/21905) - 2026-02-06
+* [Pull Request] [perf: don't return hashes of blinded nodes](https://github.com/paradigmxyz/reth/pull/22510) - 2026-02-23
+* [Pull Request] [perf: compute storage roots in a separate task](https://github.com/paradigmxyz/reth/pull/22549) - 2026-02-24
+* [Pull Request] [perf: share highest executed tx with prewarming](https://github.com/paradigmxyz/reth/pull/22621) - 2026-02-26
+* [Pull Request] [perf: prepare txenvs in parallel](https://github.com/paradigmxyz/reth/pull/22656) - 2026-02-27
+* [Pull Request] [perf: decrease sparse trie task updates batch size](https://github.com/paradigmxyz/reth/pull/22917) - 2026-03-10
 ## Q4 2025
 
 
@@ -35,26 +36,26 @@ Team: [Reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr)
 * [Commit] [refactor: remove needless collect() calls in trie tests (#18937)](https://github.com/paradigmxyz/reth/commit/5c18df9889941837e61929be4b51abb75f07f152) - 2025-10-13
 * [Pull Request] [refactor: unify `Pipeline` creation codepaths](https://github.com/paradigmxyz/reth/pull/18955) - 2025-10-13
 * [Commit] [refactor: unify Pipeline creation codepaths](https://github.com/paradigmxyz/reth/commit/bdadef6812ba52fe7e412e298386557f0caa1a0b) - 2025-10-13
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [feat: stricter bound](https://github.com/paradigmxyz/reth/pull/19049) - 2025-10-15
 * [Issue] [Replace `CacheDB` usage in RPC with `State<DB>`](https://github.com/paradigmxyz/reth/issues/19148) - 2025-10-20
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [fix: return hashed peer key as id](https://github.com/paradigmxyz/reth/pull/19245) - 2025-10-22
 * [Issue] [Make `extra_data_size_limit` configurable on `EthBeaconConsensus`](https://github.com/paradigmxyz/reth/issues/19428) - 2025-10-31
-* [Pull Request] []() - 2025-11-04
+* [Pull Request] [fix: use cost when checking fee cap](https://github.com/paradigmxyz/reth/pull/19493) - 2025-11-04
 
 * [Issue] [Add `EthChainSpec::name` method](https://github.com/paradigmxyz/reth/issues/19635) - 2025-11-10
-* [Pull Request] []() - 2025-11-18
-* [Pull Request] []() - 2025-11-22
-* [Pull Request] []() - 2025-11-24
+* [Pull Request] [feat: `EthApiError::from_revert`](https://github.com/paradigmxyz/reth/pull/19836) - 2025-11-18
+* [Pull Request] [refactor(e2e): relax bounds](https://github.com/paradigmxyz/reth/pull/19913) - 2025-11-22
+* [Pull Request] [fix: correctly fetch pending hashes](https://github.com/paradigmxyz/reth/pull/19938) - 2025-11-24
 * [Issue] [Upstream `DebugInspector`](https://github.com/paradigmxyz/reth/issues/19932) - 2025-11-24
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [fix: change `Receipt` rlp](https://github.com/paradigmxyz/reth/pull/20074) - 2025-12-02
+* [Pull Request] [fix: add missing 2718 impl for receipt](https://github.com/paradigmxyz/reth/pull/20137) - 2025-12-05
+* [Pull Request] [feat: add helper method to eth validator](https://github.com/paradigmxyz/reth/pull/20206) - 2025-12-08
+* [Pull Request] [perf: recovery backpressure](https://github.com/paradigmxyz/reth/pull/20229) - 2025-12-09
+* [Pull Request] [perf: use LRU eviction policy for precompile cache](https://github.com/paradigmxyz/reth/pull/20527) - 2025-12-19
 * [Pull Request] []() - 2025-12-20
 [bluealloy/revm](https://github.com/bluealloy/revm)
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-14
+* [Pull Request] [feat: generic Context::new](https://github.com/bluealloy/revm/pull/3156) - 2025-11-10
+* [Pull Request] [fix: correctly handle selfdestruct cold load](https://github.com/bluealloy/revm/pull/3174) - 2025-11-14
 ## Q3 2025
 
 

--- a/members/leolara.md
+++ b/members/leolara.md
@@ -10,5 +10,5 @@ Github: [@leolara](https://github.com/leolara)
 
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-03-04
+* [Pull Request] [Restore randomized blocks test generator](https://github.com/ethereum/consensus-specs/pull/4872) - 2026-01-29
+* [Pull Request] [Port ssz_generic to pytest](https://github.com/ethereum/consensus-specs/pull/4956) - 2026-03-04

--- a/members/lightclient.md
+++ b/members/lightclient.md
@@ -12,16 +12,16 @@ Team: Geth
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-03
+* [Pull Request] [core: implement EIP-7701, native account abstraction](https://github.com/ethereum/go-ethereum/pull/33520) - 2026-01-03
 
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [build: remove circleci config](https://github.com/ethereum/go-ethereum/pull/33616) - 2026-01-15
 * [Pull Request] []() - 2026-01-17
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [Update EIP-5069: add concept of associate editors](https://github.com/ethereum/EIPs/pull/11035) - 2026-01-06
 
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [Update EIP-8141: fix typo](https://github.com/ethereum/EIPs/pull/11305) - 2026-02-11
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-08
+* [Pull Request] [Add Bosul to go-ethereum](https://github.com/protocolguild/documentation/pull/462) - 2026-01-08
 
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [Headliner Breakout: EIP-8141 Frame Transaction, March 5, 2026](https://github.com/ethereum/pm/issues/1954) - 2026-03-02
@@ -34,10 +34,10 @@ Team: Geth
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
 * [Pull Request] [cmd/geth: add flag to set genesis](https://github.com/ethereum/go-ethereum/pull/32844) - 2025-10-07
-* [Pull Request] []() - 2025-11-14
+* [Pull Request] [github: add auto pr closer](https://github.com/ethereum/go-ethereum/pull/33189) - 2025-11-14
 
 [ethereum/pm](https://github.com/ethereum/pm)
-* [Pull Request] []() - 2025-11-27
+* [Pull Request] [Add geth coordinators](https://github.com/ethereum/pm/pull/1821) - 2025-11-27
 ## Q3 2025
 
 

--- a/members/lightclient.md
+++ b/members/lightclient.md
@@ -20,6 +20,7 @@ Team: Geth
 * [Pull Request] [Update EIP-5069: add concept of associate editors](https://github.com/ethereum/EIPs/pull/11035) - 2026-01-06
 
 * [Pull Request] [Update EIP-8141: fix typo](https://github.com/ethereum/EIPs/pull/11305) - 2026-02-11
+* [Review] [Review on: Update EIP-8141: Add EOA support](https://github.com/ethereum/EIPs/pull/11379#pullrequestreview-3922408317) - 2026-03-10
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] [Add Bosul to go-ethereum](https://github.com/protocolguild/documentation/pull/462) - 2026-01-08
 

--- a/members/louistsai-csie.md
+++ b/members/louistsai-csie.md
@@ -15,3 +15,10 @@ Github: [@louistsai-csie](https://github.com/louistsai-csie)
 * [Issue] [Add `target_opcode` field in fixture for benchmark](https://github.com/ethereum/execution-specs/issues/2208) - 2026-02-13
 * [Issue] [Refactor benchmark generators to enforce transaction dependencies post-Amsterdam](https://github.com/ethereum/execution-specs/issues/2204) - 2026-02-13
 * [Issue] [Refactor the state benchmark to cover existing/non-existing and cached/uncached scenarios.](https://github.com/ethereum/execution-specs/issues/2320) - 2026-02-25
+* [Review] [Review on: feat(tests): add missing legacy modexp cases with oversized lengths](https://github.com/ethereum/execution-specs/pull/2447#pullrequestreview-3920247001) - 2026-03-10
+* [Review] [Review on: feat(tests): port goevmlab regression tests for EELS consensus bugs ](https://github.com/ethereum/execution-specs/pull/2457#pullrequestreview-3920067146) - 2026-03-10
+* [Review] [Review on: feat(tests): port goevmlab regression tests for EELS consensus bugs ](https://github.com/ethereum/execution-specs/pull/2457#pullrequestreview-3920156030) - 2026-03-10
+* [Review] [Review on: feat(tests): port goevmlab regression tests for EELS consensus bugs ](https://github.com/ethereum/execution-specs/pull/2457#pullrequestreview-3920175675) - 2026-03-10
+* [Review] [Review on: chore(tests): delete already-ported extCodeHash static file](https://github.com/ethereum/execution-specs/pull/2463#pullrequestreview-3922449373) - 2026-03-10
+* [Review] [Review on: refactor(spec): unify forgotten gas constants in spec](https://github.com/ethereum/execution-specs/pull/2383#pullrequestreview-3920429913) - 2026-03-10
+* [Review] [Review on: feat(tests): port EXTCODEHASH subcall CREATE2 OOG test](https://github.com/ethereum/execution-specs/pull/2458#pullrequestreview-3919513010) - 2026-03-10

--- a/members/lu-pinto.md
+++ b/members/lu-pinto.md
@@ -11,25 +11,25 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Alu
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [Add repeat option to BlockchainTestSubCommand](https://github.com/besu-eth/besu/pull/9609) - 2026-01-07
+* [Pull Request] [Add size() and toHexString() in BytesHolder](https://github.com/besu-eth/besu/pull/9737) - 2026-02-04
 * [Issue] [Sync slow down for pre-Byzantium blocks](https://github.com/hyperledger/besu/issues/9905) - 2026-02-26
 * [Issue] [Contention lock in parallel transaction processing](https://github.com/hyperledger/besu/issues/9904) - 2026-02-26
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [Implement div sdiv with longs](https://github.com/besu-eth/besu/pull/9923) - 2026-02-28
 ## Q4 2025
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
 * [Pull Request] [Fix support for gitworktrees](https://github.com/hyperledger/besu/pull/9288) - 2025-10-10
-* [Pull Request] []() - 2025-10-17
+* [Pull Request] [implement trace filtering by opcode in debug_* RPCs](https://github.com/besu-eth/besu/pull/9335) - 2025-10-17
 * [Issue] [Add optional opcodes tracing parameter](https://github.com/hyperledger/besu/issues/9334) - 2025-10-17
-* [Pull Request] []() - 2025-10-31
+* [Pull Request] [reimplement div and sdiv](https://github.com/besu-eth/besu/pull/9391) - 2025-10-31
 * [Issue] [Reimplement UInt256.limbs fully in Big endian instead of Little endian](https://github.com/hyperledger/besu/issues/9475) - 2025-11-20
 
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-10
+* [Pull Request] [Remove unnecessary BlockValues dependency from ethereum/core project](https://github.com/besu-eth/besu/pull/9514) - 2025-11-28
+* [Pull Request] [Remove DelegatingBytes* dependency from classes](https://github.com/besu-eth/besu/pull/9556) - 2025-12-10
 [consensys/tuweni](https://github.com/consensys/tuweni)
-* [Pull Request] []() - 2025-11-27
+* [Pull Request] [Changes to devp2p project to accomodate bytes v2](https://github.com/Consensys/tuweni/pull/59) - 2025-11-27
 ## Q3 2025
 
 

--- a/members/lu-pinto.md
+++ b/members/lu-pinto.md
@@ -16,6 +16,9 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Alu
 * [Issue] [Sync slow down for pre-Byzantium blocks](https://github.com/hyperledger/besu/issues/9905) - 2026-02-26
 * [Issue] [Contention lock in parallel transaction processing](https://github.com/hyperledger/besu/issues/9904) - 2026-02-26
 * [Pull Request] [Implement div sdiv with longs](https://github.com/besu-eth/besu/pull/9923) - 2026-02-28
+* [Review] [Review on: Fix addMod case in Modulus256](https://github.com/besu-eth/besu/pull/10001#pullrequestreview-3921842733) - 2026-03-10
+* [Review] [Review on: Fix addMod case in Modulus256](https://github.com/besu-eth/besu/pull/10001#pullrequestreview-3922612681) - 2026-03-10
+* [Review] [Review on: Intrinsify byte-long conversion in UInt256](https://github.com/besu-eth/besu/pull/9976#pullrequestreview-3924527771) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/lucassaldanha.md
+++ b/members/lucassaldanha.md
@@ -16,21 +16,21 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Alucass
 * [Issue] [Add partial message support for PeerDAS data column propagation](https://github.com/Consensys/teku/issues/10284) - 2026-01-21
 * [Issue] [Add support for partial messages](https://github.com/Consensys/teku/issues/10283) - 2026-01-20
 
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Updated discovery to 26.1.0](https://github.com/Consensys/teku/pull/10366) - 2026-02-12
+* [Pull Request] [Update .gitignore to include claude personal config](https://github.com/Consensys/teku/pull/10449) - 2026-03-05
+* [Pull Request] [Optimizing blobs deserialization on Engine API](https://github.com/Consensys/teku/pull/10457) - 2026-03-06
 [libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p)
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Updated rpc protobuf definition for partial messages](https://github.com/libp2p/jvm-libp2p/pull/434) - 2026-01-21
 * [Pull Request] []() - 2026-01-27
 * [Issue] [Integrate jvm-libp2p into gossipsub-interop test](https://github.com/libp2p/jvm-libp2p/issues/439) - 2026-02-12
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [Add support for Extension Control Messages (gossipsub v1.3) 1/2](https://github.com/libp2p/jvm-libp2p/pull/438) - 2026-02-11
 * [Issue] [Investigate how extension control messages can affect peer scoring](https://github.com/libp2p/jvm-libp2p/issues/437) - 2026-02-11
 * [Issue] [Add support for Extension Control Messages (gossipsub v1.3)](https://github.com/libp2p/jvm-libp2p/issues/436) - 2026-02-11
 * [Issue] [Add support for partial messages extension](https://github.com/libp2p/jvm-libp2p/issues/435) - 2026-02-11
-* [Pull Request] []() - 2026-02-16
+* [Pull Request] [Sending control extension message to remote peers](https://github.com/libp2p/jvm-libp2p/pull/442) - 2026-02-16
 * [Issue] [Feature flag for supported extensions](https://github.com/libp2p/jvm-libp2p/issues/441) - 2026-02-16
 * [Issue] [Investigate impact of splitting control extension messages from extensions messages](https://github.com/libp2p/jvm-libp2p/issues/440) - 2026-02-16
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [Gossip Extensions feature flag](https://github.com/libp2p/jvm-libp2p/pull/443) - 2026-02-17
 * [Issue] [Refine DoS protection and other security/performance concerns](https://github.com/libp2p/jvm-libp2p/issues/449) - 2026-02-20
 * [Issue] [Eager push of partial messages](https://github.com/libp2p/jvm-libp2p/issues/448) - 2026-02-20
 * [Issue] [Review peer scoring impact of partial messages](https://github.com/libp2p/jvm-libp2p/issues/447) - 2026-02-20
@@ -40,7 +40,12 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Alucass
 * [Pull Request] []() - 2026-02-19
 
 [consensys/discovery](https://github.com/consensys/discovery)
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [Update CI badge in README.md](https://github.com/Consensys/discovery/pull/201) - 2026-02-25
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [Change getPayload timeout to 2s](https://github.com/Consensys/teku/pull/10473) - 2026-03-11
+* [Pull Request] [Engine api optimizations](https://github.com/Consensys/teku/pull/10469) - 2026-03-10
+* [Commit] [Engine api optimizations (#10469)](https://github.com/Consensys/teku/commit/c1d8031e23e5f2570be17a05b8d0407401038cf4) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/lucassaldanha.md
+++ b/members/lucassaldanha.md
@@ -19,6 +19,7 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Alucass
 * [Pull Request] []() - 2026-02-12
 * [Pull Request] []() - 2026-03-05
 * [Pull Request] []() - 2026-03-06
+* [Pull Request] []() - 2026-03-11
 [libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p)
 * [Pull Request] []() - 2026-01-21
 * [Pull Request] []() - 2026-01-27

--- a/members/lukaszrozmej.md
+++ b/members/lukaszrozmej.md
@@ -12,18 +12,21 @@ Team: [NethermindEth contributions](https://github.com/LukaszRozmej?org=Nethermi
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-08
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-04
+* [Pull Request] [Remove unneded RPC types in zk-vm](https://github.com/NethermindEth/nethermind/pull/10141) - 2026-01-07
+* [Pull Request] [Optimization/prewarmer per sender](https://github.com/NethermindEth/nethermind/pull/10330) - 2026-01-27
+* [Pull Request] [zkvm wrk refactor](https://github.com/NethermindEth/nethermind/pull/10375) - 2026-02-01
+* [Pull Request] [Harden rpc transaction validations](https://github.com/NethermindEth/nethermind/pull/10395) - 2026-02-03
+* [Pull Request] [Fixes 4 flaky test + refactors dbs](https://github.com/NethermindEth/nethermind/pull/10407) - 2026-02-04
+* [Pull Request] [more Agents changes](https://github.com/NethermindEth/nethermind/pull/10461) - 2026-02-08
+* [Pull Request] [Add complex LogIndex integration tests](https://github.com/NethermindEth/nethermind/pull/10425) - 2026-02-09
+* [Pull Request] [perf: compute tokensInCallData once per transaction in intrinsic gas calculation](https://github.com/NethermindEth/nethermind/pull/10586) - 2026-02-19
+* [Pull Request] [feat: zkVM compatibility](https://github.com/NethermindEth/nethermind/pull/10561) - 2026-02-23
+* [Pull Request] [Remove spec decorators](https://github.com/NethermindEth/nethermind/pull/10639) - 2026-02-27
+* [Pull Request] [Fix IPC JSON-RPC framing for large payloads without delimiter](https://github.com/NethermindEth/nethermind/pull/10718) - 2026-03-04
 * [Pull Request] []() - 2026-03-07
+
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Pull Request] [Flat/snap sync refactor](https://github.com/NethermindEth/nethermind/pull/10772) - 2026-03-10
 ## Q4 2025
 
 
@@ -51,10 +54,10 @@ Team: [NethermindEth contributions](https://github.com/LukaszRozmej?org=Nethermi
 * [Commit] [better description](https://github.com/NethermindEth/nethermind/commit/d99c16315064a1124ffba47fa9bf201fbcdf0c4b) - 2025-10-13
 * [Pull Request] [Restrict IPC socket to owner-only mode if set](https://github.com/NethermindEth/nethermind/pull/9449) - 2025-10-13
 
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [Fix Jovian fork id](https://github.com/NethermindEth/nethermind/pull/9877) - 2025-12-03
+* [Pull Request] [Remove parsing Uint256 from statics](https://github.com/NethermindEth/nethermind/pull/9980) - 2025-12-19
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-31
+* [Pull Request] [Add EIP: Dynamic State Pricing for Steady Growth](https://github.com/ethereum/EIPs/pull/10667) - 2025-10-31
 ## Q3 2025
 
 

--- a/members/lukaszrozmej.md
+++ b/members/lukaszrozmej.md
@@ -27,6 +27,20 @@ Team: [NethermindEth contributions](https://github.com/LukaszRozmej?org=Nethermi
 
 [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
 * [Pull Request] [Flat/snap sync refactor](https://github.com/NethermindEth/nethermind/pull/10772) - 2026-03-10
+* [Review] [Review on: Add multi-platform CI test matrix (arm64, Windows, macOS)](https://github.com/NethermindEth/nethermind/pull/10761#pullrequestreview-3924584904) - 2026-03-10
+* [Review] [Review on: Flat/snap sync refactor](https://github.com/NethermindEth/nethermind/pull/10772#pullrequestreview-3923766369) - 2026-03-10
+* [Review] [Review on: fix: Add new RLP decoders for zkEVM](https://github.com/NethermindEth/nethermind/pull/10773#pullrequestreview-3924639105) - 2026-03-10
+* [Review] [Review on: Fix rare `IndexOutOfRangeException` in `eth_getLogs` when block data is missing](https://github.com/NethermindEth/nethermind/pull/10771#pullrequestreview-3923808595) - 2026-03-10
+* [Review] [Review on: Update agent rules and review skill](https://github.com/NethermindEth/nethermind/pull/10733#pullrequestreview-3921063436) - 2026-03-10
+* [Review] [Review on: docs: Clarify guideline about infra](https://github.com/NethermindEth/nethermind/pull/10767#pullrequestreview-3923967431) - 2026-03-10
+* [Review] [Review on: Reset GasUsed when simulating txs](https://github.com/NethermindEth/nethermind/pull/10766#pullrequestreview-3922373226) - 2026-03-10
+* [Review] [Review on: Enforce GasCap across debug and trace RPC methods](https://github.com/NethermindEth/nethermind/pull/10457#pullrequestreview-3922304752) - 2026-03-10
+* [Review] [Review on: FlatDB dictionary lookup optimization](https://github.com/NethermindEth/nethermind/pull/10738#pullrequestreview-3922617452) - 2026-03-10
+* [Review] [Review on: FlatDB dictionary lookup optimization](https://github.com/NethermindEth/nethermind/pull/10738#pullrequestreview-3922681463) - 2026-03-10
+* [Review] [Review on: chore: add code review instructions for GitHub Copilot](https://github.com/NethermindEth/nethermind/pull/10602#pullrequestreview-3921092424) - 2026-03-10
+* [Review] [Review on: Fix assertoor workflow: bump setup-python to v6](https://github.com/NethermindEth/nethermind/pull/10645#pullrequestreview-3921086928) - 2026-03-10
+* [Review] [Review on: feat: add ci reporter action](https://github.com/NethermindEth/nethermind/pull/10564#pullrequestreview-3921103119) - 2026-03-10
+* [Review] [Review on: Eliminate per-instance ValueFactory delegate allocations in PrewarmerScopeProvider](https://github.com/NethermindEth/nethermind/pull/10754#pullrequestreview-3921044040) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/lukaszrozmej.md
+++ b/members/lukaszrozmej.md
@@ -24,6 +24,7 @@ Team: [NethermindEth contributions](https://github.com/LukaszRozmej?org=Nethermi
 * [Pull Request] []() - 2026-02-27
 * [Pull Request] []() - 2026-03-04
 * [Pull Request] []() - 2026-03-07
+* [Pull Request] []() - 2026-03-10
 ## Q4 2025
 
 

--- a/members/lupin012.md
+++ b/members/lupin012.md
@@ -12,27 +12,31 @@ Team: [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=autho
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-02
+* [Pull Request] [rpc: add benchEstimateGas](https://github.com/erigontech/erigon/pull/18539) - 2026-01-02
 * [Pull Request] []() - 2026-01-03
-* [Pull Request] []() - 2026-01-08
+* [Pull Request] [QA: update rpcTest version](https://github.com/erigontech/erigon/pull/18592) - 2026-01-08
 
-* [Pull Request] []() - 2026-01-25
-* [Pull Request] []() - 2026-02-21
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-07
+* [Pull Request] [rpc: add blockRangeLimit param for API works on blocks range](https://github.com/erigontech/erigon/pull/18798) - 2026-01-25
+* [Pull Request] [rpc: fix GetBlockTransactionCountByNumber with Pending](https://github.com/erigontech/erigon/pull/19335) - 2026-02-21
+* [Pull Request] [rpc: impl trace_rawTransaction](https://github.com/erigontech/erigon/pull/19524) - 2026-03-03
+* [Pull Request] [rpc: add --rpc.logs.maxresults limit on log rpc-API](https://github.com/erigontech/erigon/pull/19721) - 2026-03-07
 * [Issue] [Rpcdaemon: eth_getBlockReceipts triggers OS OOM killer during performance tests.](https://github.com/erigontech/erigon/issues/19720) - 2026-03-07
 * [Issue] [Erigon is OOM killed by OS during eth_getLogs()](https://github.com/erigontech/erigon/issues/19719) - 2026-03-07
+* [Pull Request] [rpc: fix eth_createAccessList ](https://github.com/erigontech/erigon/pull/19688) - 2026-03-10
+* [Pull Request] [rpc: fix eth_estimateGas](https://github.com/erigontech/erigon/pull/19621) - 2026-03-10
+* [Commit] [rpc: fix eth_createAccessList  (#19688)](https://github.com/erigontech/erigon/commit/9544a1914a2faa67c7635834bd8f6549f8c476b7) - 2026-03-10
+* [Commit] [rpc: fix eth_estimateGas (#19621)](https://github.com/erigontech/erigon/commit/0596d89cdde87f41b94b897e52bd8f3ea075abaf) - 2026-03-10
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
-* [Pull Request] []() - 2026-01-11
-* [Pull Request] []() - 2026-01-15
-* [Pull Request] []() - 2026-01-24
+* [Pull Request] [integration: add tests with call flat tracer](https://github.com/erigontech/rpc-tests/pull/509) - 2026-01-11
+* [Pull Request] [integration: eth_callMany fix expected responses](https://github.com/erigontech/rpc-tests/pull/511) - 2026-01-15
+* [Pull Request] [integration: fix expected result for some tests on latest](https://github.com/erigontech/rpc-tests/pull/512) - 2026-01-24
 * [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [integration: debug_trace* fix gas cost in case out of gas](https://github.com/erigontech/rpc-tests/pull/516) - 2026-02-04
+* [Pull Request] [integration: debug_traceBlockByNumber: fix revertReason in case EVM exception](https://github.com/erigontech/rpc-tests/pull/520) - 2026-02-15
+* [Pull Request] [integration: fix json stream (debug_traceCall(), trace_filter()) with error](https://github.com/erigontech/rpc-tests/pull/525) - 2026-02-17
 * [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [integration: enable trace_rawTransaction](https://github.com/erigontech/rpc-tests/pull/526) - 2026-02-27
+* [Pull Request] [integration: debug_traceCall fix exp error with withdrawals](https://github.com/erigontech/rpc-tests/pull/527) - 2026-02-28
 * [Pull Request] []() - 2026-03-02
 ## Q4 2025
 
@@ -53,29 +57,29 @@ Team: [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=autho
 * [Commit] [add logs](https://github.com/erigontech/erigon/commit/7a7b8ef5a354920eb49bdd9cf69c978670087fa3) - 2025-10-12
 * [Commit] [lint](https://github.com/erigontech/erigon/commit/1c8081274baa07d91357afd2fa729e79749ce0f0) - 2025-10-12
 * [Commit] [imp, getReceipt with replay prevTx](https://github.com/erigontech/erigon/commit/d58769fdf346d19078455d6234965ba2fd831ed3) - 2025-10-12
-* [Pull Request] []() - 2025-10-18
-* [Pull Request] []() - 2025-10-24
-* [Pull Request] []() - 2025-10-26
+* [Pull Request] [rpcdaemon: move allocation to sharedDomain only in case calcPostState](https://github.com/erigontech/erigon/pull/17533) - 2025-10-18
+* [Pull Request] [rpcdaemon: eth_createAccessList add support StateOverrides](https://github.com/erigontech/erigon/pull/17653) - 2025-10-24
+* [Pull Request] [rpcdaemon: debug_traceBlockByNumber(): add more clear error in case bn not found](https://github.com/erigontech/erigon/pull/17663) - 2025-10-26
 * [Issue] [SharedDomain doesn't work via gRPC](https://github.com/erigontech/erigon/issues/17661) - 2025-10-26
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-09
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-12-06
-* [Pull Request] []() - 2025-12-13
-* [Pull Request] []() - 2025-12-22
-* [Pull Request] []() - 2025-12-28
+* [Pull Request] [rpcdaemon: fix prestate with DiffMode with tx failed ](https://github.com/erigontech/erigon/pull/17808) - 2025-11-07
+* [Pull Request] [rpcdaemon: add support includeEmpty](https://github.com/erigontech/erigon/pull/17823) - 2025-11-09
+* [Pull Request] [rpc: prestate: codeHash is always present even if code is disable](https://github.com/erigontech/erigon/pull/18080) - 2025-11-27
+* [Pull Request] [rpc: eth_getLogs() change error code for invalid parameter errors](https://github.com/erigontech/erigon/pull/18199) - 2025-12-06
+* [Pull Request] [[3.3] cherry-pick fix eth_getLogs() for hive](https://github.com/erigontech/erigon/pull/18283) - 2025-12-13
+* [Pull Request] [rpc: trace_call add support StateOverrides.precompiler](https://github.com/erigontech/erigon/pull/18401) - 2025-12-22
+* [Pull Request] [integration_test: dump new rpc test version with more tests](https://github.com/erigontech/erigon/pull/18484) - 2025-12-28
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
 * [Commit] [integration: add debug_traceCall test for Gnosis (#470)](https://github.com/erigontech/rpc-tests/commit/627c1e1ff3fc3e52d9c6d23ca3fd69a727b1d1ae) - 2025-10-03
 * [Commit] [remove wrong chr](https://github.com/erigontech/rpc-tests/commit/4383d9aeb6fd73d640c82d9503c6ff742f54706e) - 2025-10-03
 * [Commit] [integration: eth_estimateGas with state/block overrides (#467)](https://github.com/erigontech/rpc-tests/commit/ade828fa9f2f386ff67fe6b42d630dcc19542e20) - 2025-10-04
-* [Pull Request] []() - 2025-10-31
-* [Pull Request] []() - 2025-11-06
-* [Pull Request] []() - 2025-11-14
-* [Pull Request] []() - 2025-11-23
-* [Pull Request] []() - 2025-11-29
-* [Pull Request] []() - 2025-12-04
+* [Pull Request] [integration: add tests with prestateTracer (diffMode=true) for EIP 6780](https://github.com/erigontech/rpc-tests/pull/483) - 2025-10-31
+* [Pull Request] [integration: fix prestate in debug_trace* for failed txs](https://github.com/erigontech/rpc-tests/pull/485) - 2025-11-06
+* [Pull Request] [integration: add tests on eth_estimateGas with stateOverrides](https://github.com/erigontech/rpc-tests/pull/489) - 2025-11-14
+* [Pull Request] [integration: debug_traceBlockByNumber with callTracer and prestate in latest block](https://github.com/erigontech/rpc-tests/pull/495) - 2025-11-23
+* [Pull Request] [integration: update eth_simulateV1, eth_getBlockReceipts expected results w/ commitment history](https://github.com/erigontech/rpc-tests/pull/498) - 2025-11-29
+* [Pull Request] [integration: trace_call/eth_traceCallMany only with stateDiff](https://github.com/erigontech/rpc-tests/pull/502) - 2025-12-04
 * [Pull Request] []() - 2025-12-07
-* [Pull Request] []() - 2025-12-16
+* [Pull Request] [integration: debug_traceTransaction and debug_traceCall add testd](https://github.com/erigontech/rpc-tests/pull/506) - 2025-12-16
 ## Q3 2025
 
 

--- a/members/lupin012.md
+++ b/members/lupin012.md
@@ -26,6 +26,8 @@ Team: [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=autho
 * [Pull Request] [rpc: fix eth_estimateGas](https://github.com/erigontech/erigon/pull/19621) - 2026-03-10
 * [Commit] [rpc: fix eth_createAccessList  (#19688)](https://github.com/erigontech/erigon/commit/9544a1914a2faa67c7635834bd8f6549f8c476b7) - 2026-03-10
 * [Commit] [rpc: fix eth_estimateGas (#19621)](https://github.com/erigontech/erigon/commit/0596d89cdde87f41b94b897e52bd8f3ea075abaf) - 2026-03-10
+* [Review] [Review on: rpc: eth_gasPrice() fix & optimisation](https://github.com/erigontech/erigon/pull/19678#pullrequestreview-3924912823) - 2026-03-10
+* [Review] [Review on: rpc: eth_gasPrice() fix & optimisation](https://github.com/erigontech/erigon/pull/19678#pullrequestreview-3924913799) - 2026-03-10
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
 * [Pull Request] [integration: add tests with call flat tracer](https://github.com/erigontech/rpc-tests/pull/509) - 2026-01-11
 * [Pull Request] [integration: eth_callMany fix expected responses](https://github.com/erigontech/rpc-tests/pull/511) - 2026-01-15

--- a/members/macfarla.md
+++ b/members/macfarla.md
@@ -45,6 +45,19 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ama
 * [Commit] [enable local gradle caching  (#10008)](https://github.com/besu-eth/besu/commit/0b0839634788fbfce5a605716c4b9e94b3b98eab) - 2026-03-10
 * [Commit] [Add config option for max blobs per block (#9983)](https://github.com/besu-eth/besu/commit/0f0e7b1bdcc501bdffd013bc699fd35f6f1d3650) - 2026-03-10
 * [Commit] [disable forest TraceJsonRpcHttpBySpecTest (#10005)](https://github.com/besu-eth/besu/commit/a00992a4228154ee1eb18646d13222a09df649a1) - 2026-03-10
+* [Pull Request] [clean stop bws if world state unavailable](https://github.com/besu-eth/besu/pull/10021) - 2026-03-11
+* [Review] [Review on: fix: add missing return for failed future in TransactionPool SaveRest…](https://github.com/besu-eth/besu/pull/10020#pullrequestreview-3926294501) - 2026-03-11
+* [Review] [Review on: Remove Peer Task System feature toggle from DownloadBodiesStep](https://github.com/besu-eth/besu/pull/9952#pullrequestreview-3926276105) - 2026-03-11
+* [Review] [Review on: Limit pooled tx requests by size and remove pre-eth/68 transaction announcement support](https://github.com/besu-eth/besu/pull/9990#pullrequestreview-3926223412) - 2026-03-11
+* [Review] [Review on: Migrate all Guava caches to Caffeine](https://github.com/besu-eth/besu/pull/9909#pullrequestreview-3925682554) - 2026-03-10
+* [Review] [Review on: Check new files for the correct copyright header in th CI](https://github.com/besu-eth/besu/pull/10012#pullrequestreview-3925473577) - 2026-03-10
+* [Review] [Review on: Check new files for the correct copyright header in th CI](https://github.com/besu-eth/besu/pull/10012#pullrequestreview-3925478306) - 2026-03-10
+* [Review] [Review on: Fix addMod case in Modulus256](https://github.com/besu-eth/besu/pull/10001#pullrequestreview-3925251261) - 2026-03-10
+* [Review] [Review on: Implement `txpool_status` RPC method](https://github.com/besu-eth/besu/pull/10002#pullrequestreview-3925202768) - 2026-03-10
+* [Review] [Review on: Implement EIP-7975: eth/70 - partial block receipt lists](https://github.com/besu-eth/besu/pull/9910#pullrequestreview-3920485191) - 2026-03-10
+* [Review] [Review on: Use existing RLP methods in trie log prune batch files](https://github.com/besu-eth/besu/pull/10009#pullrequestreview-3920451581) - 2026-03-10
+* [Review] [Review on: disable forest TraceJsonRpcHttpBySpecTest](https://github.com/besu-eth/besu/pull/10005#pullrequestreview-3919342284) - 2026-03-10
+* [Review] [Review on: fix(metrics): prevent duplicate OTel callback registration (#9653)](https://github.com/besu-eth/besu/pull/9957#pullrequestreview-3919258015) - 2026-03-10
 [consensys/tuweni](https://github.com/consensys/tuweni)
 * [Pull Request] [remove close stale workflow](https://github.com/Consensys/tuweni/pull/60) - 2026-01-06
 * [Pull Request] [remove stale workflow; add read permissions to GHA](https://github.com/Consensys/tuweni/pull/62) - 2026-01-08

--- a/members/macfarla.md
+++ b/members/macfarla.md
@@ -12,34 +12,42 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ama
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-01-05
+* [Pull Request] [Update log4j version to 2.25.3](https://github.com/besu-eth/besu/pull/9600) - 2026-01-05
 
 * [Issue] [Turn down this log: Invalid input length for P256VERIFY precompile: expected 160 bytes but got 100](https://github.com/hyperledger/besu/issues/9659) - 2026-01-21
 * [Issue] [Fallback to PoS if no consensus method defined in genesis](https://github.com/hyperledger/besu/issues/9675) - 2026-01-23
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [[MAINTAINERS.md] pullurib to emeritus](https://github.com/besu-eth/besu/pull/9685) - 2026-01-26
+* [Pull Request] [PoW removal: unused methods from MiningCoordinator](https://github.com/besu-eth/besu/pull/9712) - 2026-01-29
 * [Issue] [[PoW removal] decouple JsonBlockImporter](https://github.com/hyperledger/besu/issues/9713) - 2026-01-30
-* [Pull Request] []() - 2026-02-03
+* [Pull Request] [add changelog entry for state root parallelization](https://github.com/besu-eth/besu/pull/9733) - 2026-02-03
 * [Issue] [flaky test EphemeryTest](https://github.com/hyperledger/besu/issues/9726) - 2026-02-02
-* [Pull Request] []() - 2026-02-05
+* [Pull Request] [increase bft sync acceptance test timeout](https://github.com/besu-eth/besu/pull/9748) - 2026-02-05
 * [Issue] [flaky test BftSyncAcceptanceTest](https://github.com/hyperledger/besu/issues/9747) - 2026-02-05
 * [Issue] [flaky test BundleSelectorPluginTest](https://github.com/hyperledger/besu/issues/9744) - 2026-02-04
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [flaky Cluster AT - allow more time between stop and start](https://github.com/besu-eth/besu/pull/9754) - 2026-02-06
 * [Issue] [flaky test ClusterAcceptanceTest shouldRestartAfterStop](https://github.com/hyperledger/besu/issues/9753) - 2026-02-06
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [ignore .claude](https://github.com/besu-eth/besu/pull/9773) - 2026-02-10
 * [Issue] [debug_traceTransaction default param behavior](https://github.com/hyperledger/besu/issues/9787) - 2026-02-11
 * [Issue] [backup and restore state subcommands do not support bonsai](https://github.com/hyperledger/besu/issues/9811) - 2026-02-16
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [fix: correct Internal error code from -32602 to -32603](https://github.com/besu-eth/besu/pull/9845) - 2026-02-18
+* [Pull Request] [fix config for bft soak acceptance test task; add manual trigger GHA](https://github.com/besu-eth/besu/pull/9846) - 2026-02-19
+* [Pull Request] [Uprev gradle licence report plugin](https://github.com/besu-eth/besu/pull/9860) - 2026-02-20
+* [Pull Request] [gradle: regenerate blocks.bin when code has changed](https://github.com/besu-eth/besu/pull/9864) - 2026-02-23
+* [Pull Request] [fix: send slim account encoding in snap AccountRange responses](https://github.com/besu-eth/besu/pull/9877) - 2026-02-24
+* [Pull Request] [eth_simulateV1 allow moving multiple precompiles to same address](https://github.com/besu-eth/besu/pull/9892) - 2026-02-25
+* [Pull Request] [Flaky test bft block reward payment AT](https://github.com/besu-eth/besu/pull/9975) - 2026-03-05
 * [Issue] [besu OOM when no peers, no syncing](https://github.com/hyperledger/besu/issues/9974) - 2026-03-05
+* [Pull Request] [Snap download: Fallback to resync world state if incomplete](https://github.com/besu-eth/besu/pull/10019) - 2026-03-11
+* [Pull Request] [enable local gradle caching ](https://github.com/besu-eth/besu/pull/10008) - 2026-03-10
+* [Pull Request] [Add config option for max blobs per block](https://github.com/besu-eth/besu/pull/9983) - 2026-03-10
+* [Pull Request] [disable forest TraceJsonRpcHttpBySpecTest](https://github.com/besu-eth/besu/pull/10005) - 2026-03-10
+* [Issue] [Snap sync marks initial sync complete before pivot world state is available, causing BWS OOM loop](https://github.com/besu-eth/besu/issues/10018) - 2026-03-10
+* [Commit] [enable local gradle caching  (#10008)](https://github.com/besu-eth/besu/commit/0b0839634788fbfce5a605716c4b9e94b3b98eab) - 2026-03-10
+* [Commit] [Add config option for max blobs per block (#9983)](https://github.com/besu-eth/besu/commit/0f0e7b1bdcc501bdffd013bc699fd35f6f1d3650) - 2026-03-10
+* [Commit] [disable forest TraceJsonRpcHttpBySpecTest (#10005)](https://github.com/besu-eth/besu/commit/a00992a4228154ee1eb18646d13222a09df649a1) - 2026-03-10
 [consensys/tuweni](https://github.com/consensys/tuweni)
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-08
+* [Pull Request] [remove close stale workflow](https://github.com/Consensys/tuweni/pull/60) - 2026-01-06
+* [Pull Request] [remove stale workflow; add read permissions to GHA](https://github.com/Consensys/tuweni/pull/62) - 2026-01-08
 * [Pull Request] []() - 2026-01-28
 ## Q4 2025
 
@@ -69,22 +77,22 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ama
 * [Pull Request] []() - 2025-10-30
 * [Pull Request] []() - 2025-11-06
 * [Pull Request] []() - 2025-11-14
-* [Pull Request] []() - 2025-11-25
-* [Pull Request] []() - 2025-11-27
+* [Pull Request] [added Awaitility style async](https://github.com/besu-eth/besu/pull/9492) - 2025-11-25
+* [Pull Request] [remove PoW support frm Json block importer](https://github.com/besu-eth/besu/pull/9501) - 2025-11-27
 * [Issue] [flaky test shouldTimeoutSlowRpcMethod](https://github.com/hyperledger/besu/issues/9538) - 2025-12-05
 * [Issue] [Release 25.12.0](https://github.com/hyperledger/besu/issues/9537) - 2025-12-05
-* [Pull Request] []() - 2025-12-09
+* [Pull Request] [accept client or server timeout for flaky timeout test](https://github.com/besu-eth/besu/pull/9552) - 2025-12-09
 * [Issue] [assert glibc min version at besu startup](https://github.com/hyperledger/besu/issues/9551) - 2025-12-08
 [consensys/tuweni](https://github.com/consensys/tuweni)
-* [Pull Request] []() - 2025-10-21
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [post release snapshot version 2.7.3-SNAPSHOT](https://github.com/Consensys/tuweni/pull/50) - 2025-10-21
+* [Pull Request] [update gradle to 8.14](https://github.com/Consensys/tuweni/pull/51) - 2025-10-22
 
-* [Pull Request] []() - 2025-11-07
+* [Pull Request] [update vertx to 4.5.22](https://github.com/Consensys/tuweni/pull/52) - 2025-11-07
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-11-04
+* [Pull Request] [clients/besu: update name of snap sync flag](https://github.com/ethereum/hive/pull/1368) - 2025-11-04
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [update netty to 4.2.9.Final](https://github.com/Consensys/teku/pull/10254) - 2025-12-18
 ## Q3 2025
 
 

--- a/members/macfarla.md
+++ b/members/macfarla.md
@@ -37,6 +37,8 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Ama
 * [Pull Request] []() - 2026-02-25
 * [Pull Request] []() - 2026-03-05
 * [Issue] [besu OOM when no peers, no syncing](https://github.com/hyperledger/besu/issues/9974) - 2026-03-05
+* [Pull Request] []() - 2026-03-11
+* [Issue] [Snap sync marks initial sync complete before pivot world state is available, causing BWS OOM loop](https://github.com/besu-eth/besu/issues/10018) - 2026-03-10
 [consensys/tuweni](https://github.com/consensys/tuweni)
 * [Pull Request] []() - 2026-01-06
 * [Pull Request] []() - 2026-01-08

--- a/members/macladson.md
+++ b/members/macladson.md
@@ -12,30 +12,32 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amacl
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2026-01-01
-* [Pull Request] []() - 2026-01-07
+* [Pull Request] [Update `procfs`](https://github.com/sigp/lighthouse/pull/8608) - 2026-01-01
+* [Pull Request] [Remove duplicated `crypto` dependencies](https://github.com/sigp/lighthouse/pull/8605) - 2026-01-07
 
-* [Pull Request] []() - 2026-01-11
+* [Pull Request] [Remove `workspace_members` proc macro](https://github.com/sigp/lighthouse/pull/8644) - 2026-01-11
 * [Issue] [Expose a minimal set of core types in `consensus/types`](https://github.com/sigp/lighthouse/issues/8652) - 2026-01-13
-* [Pull Request] []() - 2026-01-15
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-21
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [Remove `execution` dependency from `core` module in `consensus/types`](https://github.com/sigp/lighthouse/pull/8666) - 2026-01-15
+* [Pull Request] [Remove remaining facade module re-exports from `consensus/types`](https://github.com/sigp/lighthouse/pull/8672) - 2026-01-16
+* [Pull Request] [Remove `syn` version `1`](https://github.com/sigp/lighthouse/pull/8678) - 2026-01-19
+* [Pull Request] [Remove `data` dependency from from `core` module in `consensus/types](https://github.com/sigp/lighthouse/pull/8694) - 2026-01-26
+* [Pull Request] [Add `testing` feature in `consensus/types`](https://github.com/sigp/lighthouse/pull/8704) - 2026-01-27
+* [Pull Request] [Remove dependency on OpenSSL](https://github.com/sigp/lighthouse/pull/8768) - 2026-02-07
+* [Pull Request] [Disable `legacy-arith` by default in `consensus/types`](https://github.com/sigp/lighthouse/pull/8695) - 2026-02-12
+* [Pull Request] [Remove `reqwest` re-exports from `eth2`](https://github.com/sigp/lighthouse/pull/8829) - 2026-02-16
+* [Pull Request] [Feature-gate all uses of `arbitrary`](https://github.com/sigp/lighthouse/pull/8867) - 2026-02-19
+* [Pull Request] [Bump `uuid` to remove duplicate](https://github.com/sigp/lighthouse/pull/8874) - 2026-02-21
+* [Pull Request] [Use `hashlink` over `lru` for `LruCache`](https://github.com/sigp/lighthouse/pull/8911) - 2026-02-27
+* [Pull Request] [Add `cargo-hack` to CI to check crate features](https://github.com/sigp/lighthouse/pull/8927) - 2026-03-02
 * [Issue] [Check feature combinations for user-facing crates](https://github.com/sigp/lighthouse/issues/8926) - 2026-03-02
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [Remove `c-kzg`](https://github.com/sigp/lighthouse/pull/8930) - 2026-03-03
 * [Issue] [Standardize `eth2` endpoint method versioning](https://github.com/sigp/lighthouse/issues/8931) - 2026-03-04
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Fix lints for Rust v1.94.0](https://github.com/sigp/lighthouse/pull/8939) - 2026-03-06
 * [Issue] [Re-examine `clippy::result_large_err` lints](https://github.com/sigp/lighthouse/issues/8943) - 2026-03-06
+* [Pull Request] [Update `/rewards` endpoints to match spec](https://github.com/sigp/lighthouse/pull/8967) - 2026-03-10
+* [Pull Request] [Remove `lighthouse/analysis` endpoints](https://github.com/sigp/lighthouse/pull/8968) - 2026-03-10
 [sigp/discv5](https://github.com/sigp/discv5)
-* [Pull Request] []() - 2026-01-10
+* [Pull Request] [Use `hashlink::LruCache` instead of `lru::LruCache`](https://github.com/sigp/discv5/pull/294) - 2026-01-10
 ## Q4 2025
 
 
@@ -43,13 +45,13 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amacl
 * [Pull Request] [Remove `ethers-core` from `execution_layer`](https://github.com/sigp/lighthouse/pull/8149) - 2025-10-01
 * [Pull Request] [Remove `context_deserialize` and import from crates.io](https://github.com/sigp/lighthouse/pull/8172) - 2025-10-08
 * [Pull Request] [Remove `safe_arith` and import from crates.io](https://github.com/sigp/lighthouse/pull/8191) - 2025-10-12
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-12-03
+* [Pull Request] [Add `eip_3076` crate](https://github.com/sigp/lighthouse/pull/8206) - 2025-10-15
+* [Pull Request] [Create `axum_utils` and begin VC HTTP API migration ](https://github.com/sigp/lighthouse/pull/8280) - 2025-10-23
+* [Pull Request] [Reduce `eth2` dependency space ](https://github.com/sigp/lighthouse/pull/8524) - 2025-12-03
 * [Issue] [Duplicated crates: Tracking Issue](https://github.com/sigp/lighthouse/issues/8547) - 2025-12-05
-* [Pull Request] []() - 2025-12-07
+* [Pull Request] [Clarify `alloy` dependencies](https://github.com/sigp/lighthouse/pull/8550) - 2025-12-07
 * [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-09
+* [Pull Request] [Add `network` feature to `eth2`](https://github.com/sigp/lighthouse/pull/8558) - 2025-12-09
 * [Pull Request] []() - 2025-12-19
 * [Pull Request] []() - 2025-12-20
 

--- a/members/marchhill.md
+++ b/members/marchhill.md
@@ -11,11 +11,11 @@ Team: [NethermindEth contributions](https://github.com/Marchhill?org=NethermindE
 
 
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [engine: EIP-7843 changes - adding slot number to fcU](https://github.com/ethereum/execution-apis/pull/731) - 2026-01-14
 * [Pull Request] []() - 2026-01-29
 
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2026-02-08
+* [Pull Request] [clients/nethermind: fix config to remove mining](https://github.com/ethereum/hive/pull/1386) - 2026-02-08
 ## Q4 2025
 
 
@@ -47,7 +47,7 @@ Team: [NethermindEth contributions](https://github.com/Marchhill?org=NethermindE
 * [Commit] [comment logs](https://github.com/NethermindEth/nethermind/commit/ba184ffca847fc7998ac0f33e4ef073e748b80ed) - 2025-10-10
 * [Commit] [engine rpc amsterdam](https://github.com/NethermindEth/nethermind/commit/a714e194239f12f4cfa940688b2c6c72ad7bbe04) - 2025-10-10
 * [Commit] [fix block building](https://github.com/NethermindEth/nethermind/commit/54a00d5a36dce973c4c831b197ed60281a5686de) - 2025-10-13
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [Optimise CALL by throwing stack underflow earlier](https://github.com/NethermindEth/nethermind/pull/9581) - 2025-10-27
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] [Marc Harvey-Hill (Nethermind) 0.5->1](https://github.com/protocolguild/documentation/pull/421) - 2025-10-01
 

--- a/members/marcindsobczak.md
+++ b/members/marcindsobczak.md
@@ -12,10 +12,10 @@ Team: [NethermindEth contributions](https://github.com/marcindsobczak?org=Nether
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-09
+* [Pull Request] [Optimize success response of engine_getBlobsV2 (and slow down non-success)](https://github.com/NethermindEth/nethermind/pull/10159) - 2026-01-09
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-12
+* [Pull Request] [Update EIP-8096: change reprice to double](https://github.com/ethereum/EIPs/pull/11063) - 2026-01-12
 ## Q4 2025
 
 
@@ -26,10 +26,10 @@ Team: [NethermindEth contributions](https://github.com/marcindsobczak?org=Nether
 * [Commit] [debug endpoint](https://github.com/NethermindEth/nethermind/commit/cc4c4e47f4c8c438927d006164df38fa760a1045) - 2025-10-03
 
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2025-12-01
+* [Pull Request] [Add RPC endpoint testing_buildBlockV1](https://github.com/ethereum/execution-apis/pull/710) - 2025-12-01
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [Add EIP: Increase Gas Cost of Point Evaluation](https://github.com/ethereum/EIPs/pull/10864) - 2025-12-23
 ## Q3 2025
 
 

--- a/members/marekm25.md
+++ b/members/marekm25.md
@@ -13,10 +13,10 @@ Team: [NethermindEth contributions](https://github.com/MarekM25?org=NethermindEt
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
 * [Issue] [Node is trying to remove one more block (at least in logs)](https://github.com/NethermindEth/nethermind/issues/10119) - 2026-01-06
-* [Pull Request] []() - 2026-01-30
+* [Pull Request] [Update README with performance highlights of Nethermind](https://github.com/NethermindEth/nethermind/pull/10359) - 2026-01-30
 * [Issue] ["Improve PR workflow"](https://github.com/NethermindEth/nethermind/issues/10374) - 2026-02-01
 * [Issue] [TransactionForRpc.EnsureDefaults not called consistently before ToTransaction](https://github.com/NethermindEth/nethermind/issues/10547) - 2026-02-16
-* [Pull Request] []() - 2026-02-21
+* [Pull Request] [chore: add review-pr Claude Code skill](https://github.com/NethermindEth/nethermind/pull/10603) - 2026-02-21
 * [Issue] [Add BlockValidator to StatelessnessExecutor](https://github.com/NethermindEth/nethermind/issues/10618) - 2026-02-23
 * [Issue] [Implement EIP-7976](https://github.com/NethermindEth/nethermind/issues/10681) - 2026-03-01
 * [Issue] [Implement EIP-7981](https://github.com/NethermindEth/nethermind/issues/10680) - 2026-03-01
@@ -29,7 +29,7 @@ Team: [NethermindEth contributions](https://github.com/MarekM25?org=NethermindEt
 * [Issue] [eth_getBalance responds with TrieException](https://github.com/NethermindEth/nethermind/issues/9408) - 2025-10-04
 * [Commit] [Refactoring HasState (#9414)](https://github.com/NethermindEth/nethermind/commit/e9a79ea7726dc5a7ba307eb2cf82613facd6d76a) - 2025-10-05
 * [Pull Request] [Refactoring HasState](https://github.com/NethermindEth/nethermind/pull/9414) - 2025-10-05
-* [Pull Request] []() - 2025-10-24
+* [Pull Request] [[WIP - ignore for now] Alloc perf get](https://github.com/NethermindEth/nethermind/pull/9559) - 2025-10-24
 * [Issue] [Big_test is failing with missing trie nodes](https://github.com/NethermindEth/nethermind/issues/9577) - 2025-10-27
 * [Issue] [[Docs] Database size and history expiry update](https://github.com/NethermindEth/nethermind/issues/9626) - 2025-11-01
 ## Q3 2025

--- a/members/marioevz.md
+++ b/members/marioevz.md
@@ -41,6 +41,7 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Pull Request] []() - 2026-03-07
 * [Issue] [chore(test-types): Rename `pre.empty_account`](https://github.com/ethereum/execution-specs/issues/2434) - 2026-03-06
 * [Issue] [feat(tests): Missing test cases for EIP-196](https://github.com/ethereum/execution-specs/issues/2433) - 2026-03-06
+* [Pull Request] []() - 2026-03-11
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] []() - 2026-01-15
 ## Q4 2025

--- a/members/marioevz.md
+++ b/members/marioevz.md
@@ -19,30 +19,31 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [All Core Devs - Testing (ACDT) #71, February 23, 2026](https://github.com/ethereum/pm/issues/1932) - 2026-02-17
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [EIP-7997 Implementation Tracker: Deterministic Factory Predeploy](https://github.com/ethereum/execution-specs/issues/1988) - 2026-01-07
-* [Pull Request] []() - 2026-01-10
+* [Pull Request] [feat(testing/forks): Implement `bytecode.gas_cost(fork)`](https://github.com/ethereum/execution-specs/pull/2002) - 2026-01-10
 
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-20
+* [Pull Request] [chore(testing/vm): Remove UndefinedOpcodes](https://github.com/ethereum/execution-specs/pull/2044) - 2026-01-19
+* [Pull Request] [feat(ci): Create Devnet Workflows](https://github.com/ethereum/execution-specs/pull/2053) - 2026-01-20
 * [Issue] [chore(testing): Replace `hashllib.sha256` with faster algorithm](https://github.com/ethereum/execution-specs/issues/2087) - 2026-01-27
 * [Issue] [Speed-up JSON infra by filling a subset of test and executing it](https://github.com/ethereum/execution-specs/issues/2090) - 2026-01-28
 * [Issue] [Mark Tests Requiring Opcode Counting](https://github.com/ethereum/execution-specs/issues/2102) - 2026-01-29
 * [Issue] [feat(testing): Stateful Engine X Format and Fill Transition Tool](https://github.com/ethereum/execution-specs/issues/2125) - 2026-02-03
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [fix(testing/execute): Phase not being correctly passed as tx request ID](https://github.com/ethereum/execution-specs/pull/2161) - 2026-02-07
+* [Pull Request] [feat(benchmarking): Optimize `IteratingBytecode`](https://github.com/ethereum/execution-specs/pull/2184) - 2026-02-11
 * [Issue] [zkEVM Projects Tracking Issue](https://github.com/ethereum/execution-specs/issues/2183) - 2026-02-10
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [refactor(testing): Refactor specs to allow reusing logic for benchmark checks](https://github.com/ethereum/execution-specs/pull/2203) - 2026-02-13
 * [Issue] [feat(all): Repricing Tool](https://github.com/ethereum/execution-specs/issues/2200) - 2026-02-12
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [fix(test-specs): Exclude full post-state/setup-tx receipts on benchmarks](https://github.com/ethereum/execution-specs/pull/2226) - 2026-02-17
 * [Issue] [refactor(test-specs): Replace `BaseExecute` with mixins on `BaseTest`](https://github.com/ethereum/execution-specs/issues/2258) - 2026-02-20
 * [Issue] [feat(specs-tests): Update EIP-8024 According to EIPs #11306](https://github.com/ethereum/execution-specs/issues/2298) - 2026-02-24
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [feat(test-cli): Stack as callargs to`Op` for `evm_bytes`](https://github.com/ethereum/execution-specs/pull/2329) - 2026-02-25
 * [Issue] [Gas repricing tooling requirements and coordination tracker](https://github.com/ethereum/execution-specs/issues/2340) - 2026-02-26
 * [Issue] [Stateful Tests CI Verification](https://github.com/ethereum/execution-specs/issues/2423) - 2026-03-05
-* [Pull Request] []() - 2026-03-07
+* [Pull Request] [chore(tests-static): Port remaining EC Pairing static tests](https://github.com/ethereum/execution-specs/pull/2443) - 2026-03-07
 * [Issue] [chore(test-types): Rename `pre.empty_account`](https://github.com/ethereum/execution-specs/issues/2434) - 2026-03-06
 * [Issue] [feat(tests): Missing test cases for EIP-196](https://github.com/ethereum/execution-specs/issues/2433) - 2026-03-06
+* [Pull Request] [feat(test-execute): Defer pre-alloc methods remote checks to batch them](https://github.com/ethereum/execution-specs/pull/2475) - 2026-03-11
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [Add Louis from STEEL, ethereum/execution-specs](https://github.com/protocolguild/documentation/pull/472) - 2026-01-15
 ## Q4 2025
 
 
@@ -60,28 +61,28 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [Fix `test_genesis_hash_available` to be fill-only](https://github.com/ethereum/execution-specs/issues/1607) - 2025-10-15
 * [Issue] [[Post-Weld] Revisit `slow` marked tests](https://github.com/ethereum/execution-specs/issues/1625) - 2025-10-16
 * [Issue] [Update the existing test_modexp_upper_bounds to run from Prague](https://github.com/ethereum/execution-specs/issues/1624) - 2025-10-16
-* [Pull Request] []() - 2025-10-21
+* [Pull Request] [chore(pytest): Fix/enable `packages/tests` unit tests](https://github.com/ethereum/execution-specs/pull/1639) - 2025-10-21
 * [Issue] [Verify Behavior of T8N in `ExecutionSpecsTransitionTool` due to `--output.basedir`](https://github.com/ethereum/execution-specs/issues/1652) - 2025-10-21
 * [Issue] [Fill Gas-Repricing Tests And Create a New Release](https://github.com/ethereum/execution-specs/issues/1656) - 2025-10-22
 * [Issue] [New test: Precompile as block coinbase/fee recipient](https://github.com/ethereum/execution-specs/issues/1669) - 2025-10-23
-* [Pull Request] []() - 2025-10-23
+* [Pull Request] [refactor(tests): Use pytest collection to load JSON fixtures](https://github.com/ethereum/execution-specs/pull/1666) - 2025-10-23
 * [Issue] [Explore creating `packages/testing-types`](https://github.com/ethereum/execution-specs/issues/1679) - 2025-10-24
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [fix(testing/specs): Fix benchmark pre-alloc grouping](https://github.com/ethereum/execution-specs/pull/1708) - 2025-10-28
 * [Issue] [Mark `Osaka` mainnet tests](https://github.com/ethereum/execution-specs/issues/1714) - 2025-10-29
 * [Issue] [Create a `README.md` for `./tests/`](https://github.com/ethereum/execution-specs/issues/1721) - 2025-10-31
 * [Issue] [FIx or reconsider `test_blockhash`](https://github.com/ethereum/execution-specs/issues/1792) - 2025-11-14
-* [Pull Request] []() - 2025-11-14
-* [Pull Request] []() - 2025-11-18
+* [Pull Request] [bug(test-benchmark): skip benchmark `test_blockhash`](https://github.com/ethereum/execution-specs/pull/1791) - 2025-11-14
+* [Pull Request] [fix(github): Fix benchmark genesis generation](https://github.com/ethereum/execution-specs/pull/1800) - 2025-11-18
 * [Issue] [Remove duplicate exception definitions](https://github.com/ethereum/execution-specs/issues/1816) - 2025-11-26
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-09
+* [Pull Request] [fix(testing): Optimize fill](https://github.com/ethereum/execution-specs/pull/1804) - 2025-12-02
+* [Pull Request] [bug(ci): Convert issue tracker to MD](https://github.com/ethereum/execution-specs/pull/1868) - 2025-12-09
 * [Issue] [Better abstraction in T8N class in `src/ethereum_spec_tools/evm_tools/t8n/__init__.py`](https://github.com/ethereum/execution-specs/issues/1883) - 2025-12-10
 * [Issue] [EIP-7805 Implementation Tracker: FOCIL](https://github.com/ethereum/execution-specs/issues/1900) - 2025-12-11
 * [Issue] [EIP-7981 Implementation Tracker: Increase access list cost](https://github.com/ethereum/execution-specs/issues/1943) - 2025-12-18
 * [Issue] [EIP-7976 Implementation Tracker: Increase Calldata Floor Cost](https://github.com/ethereum/execution-specs/issues/1942) - 2025-12-18
 * [Issue] [EIP-8038 Implementation Tracker: State-access gas cost update](https://github.com/ethereum/execution-specs/issues/1941) - 2025-12-18
 * [Issue] [EIP-2780 Implementation Tracker: Reduce intrinsic transaction gas](https://github.com/ethereum/execution-specs/issues/1940) - 2025-12-18
-* [Pull Request] []() - 2025-12-22
+* [Pull Request] [bug(test-cli): fix extract config](https://github.com/ethereum/execution-specs/pull/1947) - 2025-12-22
 [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests)
 * [Commit] [type(tests): convert create suicide during init (#1871)](https://github.com/ethereum/execution-spec-tests/commit/28ca6decef374908e7e18e4cf4e5a500a9834866) - 2025-10-02
 * [Commit] [refactor(tests): add checklist marker for eip7823 (#2115)](https://github.com/ethereum/execution-spec-tests/commit/110b5d4ae9d6c07a4ae2d5e9a2822652b0ae6172) - 2025-10-02
@@ -104,11 +105,11 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [All Core Devs - Testing (ACDT) #59, Oct 27, 2025](https://github.com/ethereum/pm/issues/1778) - 2025-10-21
 * [Issue] [All Core Devs - Testing (ACDT) #61, November 10, 2025](https://github.com/ethereum/pm/issues/1797) - 2025-11-05
-* [Pull Request] []() - 2025-11-26
+* [Pull Request] [Add Testing Coordinators for Fusaka](https://github.com/ethereum/pm/pull/1815) - 2025-11-26
 * [Issue] [All Core Devs - Testing (ACDT) #63, December 8, 2025](https://github.com/ethereum/pm/issues/1834) - 2025-12-03
 
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-12-29
+* [Pull Request] [fix(simulators/engine): Use SetBlock to reset back to cannonical chain](https://github.com/ethereum/hive/pull/1379) - 2025-12-29
 ## Q3 2025
 
 

--- a/members/marioevz.md
+++ b/members/marioevz.md
@@ -42,6 +42,10 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [chore(test-types): Rename `pre.empty_account`](https://github.com/ethereum/execution-specs/issues/2434) - 2026-03-06
 * [Issue] [feat(tests): Missing test cases for EIP-196](https://github.com/ethereum/execution-specs/issues/2433) - 2026-03-06
 * [Pull Request] [feat(test-execute): Defer pre-alloc methods remote checks to batch them](https://github.com/ethereum/execution-specs/pull/2475) - 2026-03-11
+* [Review] [Review on: feat(tests): add tests for address not warmed on aborted create](https://github.com/ethereum/execution-specs/pull/2452#pullrequestreview-3924888508) - 2026-03-10
+* [Review] [Review on: feat(tests): port codeCopyZero and delete stExtCodeHash static tests](https://github.com/ethereum/execution-specs/pull/2465#pullrequestreview-3924643633) - 2026-03-10
+* [Review] [Review on: feat(tests,spec-specs): code deposit ordering and regression tests](https://github.com/ethereum/execution-specs/pull/2468#pullrequestreview-3924757469) - 2026-03-10
+* [Review] [Review on: refactor(testing): rename empty_account() to nonexistent_account()](https://github.com/ethereum/execution-specs/pull/2462#pullrequestreview-3924268776) - 2026-03-10
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] [Add Louis from STEEL, ethereum/execution-specs](https://github.com/protocolguild/documentation/pull/472) - 2026-01-15
 ## Q4 2025

--- a/members/mariusvanderwijden.md
+++ b/members/mariusvanderwijden.md
@@ -12,11 +12,11 @@ Team: Geth
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [core/vm: implement eip-7843: SLOTNUM](https://github.com/ethereum/go-ethereum/pull/33589) - 2026-01-12
+* [Pull Request] [core: implement eip-7778: block gas accounting without refunds](https://github.com/ethereum/go-ethereum/pull/33593) - 2026-01-13
+* [Pull Request] [metrics: reduce allocations for metrics](https://github.com/ethereum/go-ethereum/pull/33699) - 2026-02-06
+* [Pull Request] [eth/catalyst: add api benchmarks](https://github.com/ethereum/go-ethereum/pull/33944) - 2026-03-03
+* [Pull Request] [go.mod: update go-eth-kzg](https://github.com/ethereum/go-ethereum/pull/33963) - 2026-03-05
 * [Pull Request] []() - 2026-03-08
 ## Q4 2025
 
@@ -25,11 +25,11 @@ Team: Geth
 * [Issue] [Flaky test: TestSizeTracker](https://github.com/ethereum/go-ethereum/issues/32984) - 2025-10-21
 * [Issue] [Migrating nodes db from leveldb to pebble](https://github.com/ethereum/go-ethereum/issues/33000) - 2025-10-22
 * [Issue] [High allocations in LogFilter](https://github.com/ethereum/go-ethereum/issues/33040) - 2025-10-28
-* [Pull Request] []() - 2025-11-03
+* [Pull Request] [go.mod: update to c-kzg v2.1.5](https://github.com/ethereum/go-ethereum/pull/33093) - 2025-11-03
 
-* [Pull Request] []() - 2025-11-07
+* [Pull Request] [core/vm: remove todo](https://github.com/ethereum/go-ethereum/pull/33120) - 2025-11-07
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [Increase mainnet DefaultBuilderGasLimit to 60M](https://github.com/OffchainLabs/prysm/pull/15979) - 2025-11-05
 
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
 * [Issue] [admin_mineBlock for deterministic miner testing](https://github.com/ethereum/execution-apis/issues/705) - 2025-11-08

--- a/members/matilda-clerke.md
+++ b/members/matilda-clerke.md
@@ -12,17 +12,17 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AMa
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [Discv5 static bootnodes](https://github.com/besu-eth/besu/pull/9809) - 2026-02-15
+* [Pull Request] [Change default batch size for snap sync download pipeline](https://github.com/besu-eth/besu/pull/9943) - 2026-03-03
 ## Q4 2025
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2025-11-03
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-12-15
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [Remove RetryingGetHeaderFromPeerByHashTask and associated peer task system feature toggle](https://github.com/besu-eth/besu/pull/9393) - 2025-11-03
+* [Pull Request] [Fix flaky test PivotBlockRetrieverTest.shouldRecoverFromUnresponsivePeer](https://github.com/besu-eth/besu/pull/9408) - 2025-11-10
+* [Pull Request] [PoS sync hackathon - draft PR to view summary of changes](https://github.com/besu-eth/besu/pull/9416) - 2025-11-12
+* [Pull Request] [Add SyncTransactionReceipt, decoder, and update LogsBloomFilter to utilise raw Bytes](https://github.com/besu-eth/besu/pull/9574) - 2025-12-15
+* [Pull Request] [Improve performance of peerselector peers](https://github.com/besu-eth/besu/pull/9586) - 2025-12-18
 ## Q3 2025
 
 

--- a/members/matilda-clerke.md
+++ b/members/matilda-clerke.md
@@ -14,6 +14,8 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3AMa
 [hyperledger/besu](https://github.com/hyperledger/besu)
 * [Pull Request] [Discv5 static bootnodes](https://github.com/besu-eth/besu/pull/9809) - 2026-02-15
 * [Pull Request] [Change default batch size for snap sync download pipeline](https://github.com/besu-eth/besu/pull/9943) - 2026-03-03
+* [Review] [Review on: EIP-8159: eth/71 - Block Access List Exchange](https://github.com/besu-eth/besu/pull/9966#pullrequestreview-3926250034) - 2026-03-11
+* [Review] [Review on: Update --bootnodes description and throw exception is mixed enode and ENR bootnodes are present](https://github.com/besu-eth/besu/pull/9955#pullrequestreview-3926008516) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/matkt.md
+++ b/members/matkt.md
@@ -16,5 +16,8 @@ Github: [@matkt](https://github.com/matkt)
 * [Issue] [EIP-7928 - Add eth/71 protocol support for BALs](https://github.com/hyperledger/besu/issues/9792) - 2026-02-12
 
 * [Pull Request] [Feature/add parallelization tests](https://github.com/besu-eth/besu/pull/10010) - 2026-03-10
+* [Review] [Review on: Amsterdam: EIP-8037: State Creation Gas Cost Increase](https://github.com/besu-eth/besu/pull/9815#pullrequestreview-3920121210) - 2026-03-10
+* [Review] [Review on: Merge trace-streaming into bal-devnet-2](https://github.com/besu-eth/besu/pull/10011#pullrequestreview-3922727156) - 2026-03-10
+* [Review] [Review on: Use existing RLP methods in trie log prune batch files](https://github.com/besu-eth/besu/pull/10009#pullrequestreview-3920298872) - 2026-03-10
 [hyperledger/besu-stateless](https://github.com/hyperledger/besu-stateless)
 * [Pull Request] [use set for the StemPrunableNodeRegistry](https://github.com/besu-eth/besu-stateless/pull/90) - 2026-02-27

--- a/members/matkt.md
+++ b/members/matkt.md
@@ -15,5 +15,6 @@ Github: [@matkt](https://github.com/matkt)
 * [Issue] [EIP-7928 - Add BALs max item protection](https://github.com/hyperledger/besu/issues/9793) - 2026-02-12
 * [Issue] [EIP-7928 - Add eth/71 protocol support for BALs](https://github.com/hyperledger/besu/issues/9792) - 2026-02-12
 
+* [Pull Request] [Feature/add parallelization tests](https://github.com/besu-eth/besu/pull/10010) - 2026-03-10
 [hyperledger/besu-stateless](https://github.com/hyperledger/besu-stateless)
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [use set for the StemPrunableNodeRegistry](https://github.com/besu-eth/besu-stateless/pull/90) - 2026-02-27

--- a/members/mattevans.md
+++ b/members/mattevans.md
@@ -12,27 +12,31 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 
 
 [ethpandaops/lab](https://github.com/ethpandaops/lab)
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [feat(payloads): add Ethrex client to filter and quick-filter options](https://github.com/ethpandaops/lab/pull/370) - 2026-01-06
 * [Pull Request] []() - 2026-01-12
 
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-05
+* [Pull Request] [feat(gas-profiler): deep link to contracts](https://github.com/ethpandaops/lab/pull/394) - 2026-02-03
+* [Pull Request] [feat(flame-graph): less jump transitions + fix search](https://github.com/ethpandaops/lab/pull/398) - 2026-02-05
 * [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [refactor(gas-profiler): paging/dates](https://github.com/ethpandaops/lab/pull/406) - 2026-02-10
+* [Pull Request] [feat(gas-profiler): add precompile gas parameters and UI support](https://github.com/ethpandaops/lab/pull/412) - 2026-02-11
+* [Pull Request] [feat(gas-profiler): show friendly syncing state when backend nodes are unavailable](https://github.com/ethpandaops/lab/pull/420) - 2026-02-12
+* [Pull Request] [feat(gas): cleanup](https://github.com/ethpandaops/lab/pull/423) - 2026-02-13
+* [Pull Request] [fix: ethrex quick filter](https://github.com/ethpandaops/lab/pull/430) - 2026-02-25
+* [Pull Request] [feat: gas profiler - receipt size](https://github.com/ethpandaops/lab/pull/431) - 2026-02-27
 [ethpandaops/cartographoor](https://github.com/ethpandaops/cartographoor)
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [feat(config.production.yaml): add ethpandaops/blob-devnets repository to discovery](https://github.com/ethpandaops/cartographoor/pull/78) - 2026-01-21
 
 [ethpandaops/xatu](https://github.com/ethpandaops/xatu)
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [feat(clickhouse): add canonical_execution_transaction_structlog_agg tables](https://github.com/ethpandaops/xatu/pull/741) - 2026-01-27
+* [Pull Request] [feat(clickhouse): add resource gas columns to structlog_agg tables](https://github.com/ethpandaops/xatu/pull/748) - 2026-02-16
+* [Pull Request] [feat(migrations): off by one - story of my life](https://github.com/ethpandaops/xatu/pull/750) - 2026-02-17
+* [Pull Request] [refactor: go-fix](https://github.com/ethpandaops/xatu/pull/751) - 2026-02-18
+* [Pull Request] [refactor: trace_identify plumbing](https://github.com/ethpandaops/xatu/pull/765) - 2026-02-23
+
+[ethpandaops/contributoor](https://github.com/ethpandaops/contributoor)
+* [Pull Request] [fix: resolve golangci-lint issues](https://github.com/ethpandaops/contributoor/pull/195) - 2026-03-11
+* [Pull Request] [chore: bump go-ethereum to v1.17.1](https://github.com/ethpandaops/contributoor/pull/194) - 2026-03-10
 ## Q4 2025
 
 
@@ -44,8 +48,8 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Commit] [fix: align custodyGroupCount type assertion with protobuf uint64](https://github.com/ethpandaops/xatu/commit/f4e9ecb9842c13a2cd92c9bb9bd2c2a1dd773801) - 2025-10-02
 * [Pull Request] [fix: align custodyGroupCount type assertion with protobuf uint64](https://github.com/ethpandaops/xatu/pull/671) - 2025-10-02
 * [Commit] [feat: add support for Tysm consensus client in cannon and sentry](https://github.com/ethpandaops/xatu/commit/ad63cc760fd16a741bf349002dbecb3fc62a8bf6) - 2025-10-02
-* [Pull Request] []() - 2025-12-07
-* [Pull Request] []() - 2025-12-08
+* [Pull Request] [fix(clmimicry): support typed *TraceEventCustodyProbe payload](https://github.com/ethpandaops/xatu/pull/699) - 2025-12-07
+* [Pull Request] [refactor(cannon): overhaul smoke test to use dynamic epoch seeding with mainnet](https://github.com/ethpandaops/xatu/pull/701) - 2025-12-08
 [ethpandaops/lab](https://github.com/ethpandaops/lab)
 * [Commit] [feat: add Grandine client logo to fork-readiness page](https://github.com/ethpandaops/lab/commit/1c418e0cc75943767453d6de25f4a7746091c035) - 2025-10-01
 * [Pull Request] [feat: add Grandine client logo to fork-readiness page](https://github.com/ethpandaops/lab/pull/113) - 2025-10-01
@@ -68,15 +72,15 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Commit] [fix(go.mod): remove local replace directive for xatu-cbt and bump to latest upstream version](https://github.com/ethpandaops/lab/commit/7b93166aab47ee22644b83d6a2e3b90028e90598) - 2025-10-10
 * [Pull Request] [feat: revendor protos with changes - made tweaks](https://github.com/ethpandaops/lab/pull/120) - 2025-10-10
 
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [refactor(DetailPage): remove fork-based conditional rendering for blob/data column charts](https://github.com/ethpandaops/lab/pull/339) - 2025-12-03
+* [Pull Request] [refactor(engine-timings): derive data from hourly & el-client](https://github.com/ethpandaops/lab/pull/358) - 2025-12-16
+* [Pull Request] [refactor: switch from hourly/daily aggregates to per-slot data for accuracy](https://github.com/ethpandaops/lab/pull/361) - 2025-12-18
 [ethpandaops/cartographoor](https://github.com/ethpandaops/cartographoor)
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-11-13
+* [Pull Request] [feat(config.production.yaml): add fusaka hardfork config for mainnet](https://github.com/ethpandaops/cartographoor/pull/51) - 2025-11-04
+* [Pull Request] [feat(client): add cartographoor client library with memory and redis providers](https://github.com/ethpandaops/cartographoor/pull/56) - 2025-11-13
 
 [ethpandaops/contributoor](https://github.com/ethpandaops/contributoor)
-* [Pull Request] []() - 2025-11-27
+* [Pull Request] [docs(README.md): add new attestation subnet CLI flags to configuration section](https://github.com/ethpandaops/contributoor/pull/163) - 2025-11-27
 ## Q3 2025
 
 

--- a/members/mattevans.md
+++ b/members/mattevans.md
@@ -33,6 +33,9 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Pull Request] []() - 2026-02-17
 * [Pull Request] []() - 2026-02-18
 * [Pull Request] []() - 2026-02-23
+
+[ethpandaops/contributoor](https://github.com/ethpandaops/contributoor)
+* [Pull Request] []() - 2026-03-11
 ## Q4 2025
 
 

--- a/members/matthewkeil.md
+++ b/members/matthewkeil.md
@@ -17,7 +17,7 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
-* [Pull Request] []() - 2025-12-09
+* [Pull Request] [fix: upgrade version of parcel/watcher that resolves](https://github.com/ChainSafe/lodestar/pull/8676) - 2025-12-09
 * [Issue] [Dashboard Update - Display which validator indices are connected to a running node](https://github.com/ChainSafe/lodestar/issues/8698) - 2025-12-16
 ## Q3 2025
 

--- a/members/mattsse.md
+++ b/members/mattsse.md
@@ -13,39 +13,40 @@ Team: Reth
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
 * [Issue] [Support additional eth_subscribe handlers](https://github.com/paradigmxyz/reth/issues/20750) - 2026-01-05
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-08
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-10
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [perf(trie): add clone_into_sorted for TrieUpdates and StorageTrieUpdates](https://github.com/paradigmxyz/reth/pull/20784) - 2026-01-06
+* [Pull Request] [perf(trie): optimize ChunkedHashedPostState sorting](https://github.com/paradigmxyz/reth/pull/20866) - 2026-01-08
+* [Pull Request] [feat(cli): add CliRunnerConfig for configurable graceful shutdown timeout](https://github.com/paradigmxyz/reth/pull/20899) - 2026-01-09
+* [Pull Request] [perf(trie): save one clock read in elapsed time calculation](https://github.com/paradigmxyz/reth/pull/20916) - 2026-01-10
+* [Pull Request] [refactor(chain-state): extract blocks_to_chain helper](https://github.com/paradigmxyz/reth/pull/21110) - 2026-01-15
 
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [feat(engine): stub Amsterdam engine API endpoints (newPayloadV5, getPayloadV6, BALs)](https://github.com/paradigmxyz/reth/pull/21344) - 2026-01-22
+* [Pull Request] [refactor(db): make Tx::inner field private with accessor](https://github.com/paradigmxyz/reth/pull/21490) - 2026-01-27
+* [Pull Request] [feat(trie): add heat tracking to ParallelSparseTrie pruning](https://github.com/paradigmxyz/reth/pull/21588) - 2026-01-29
+* [Pull Request] [refactor(engine): improve payload processor tx iterator](https://github.com/paradigmxyz/reth/pull/21658) - 2026-01-31
+* [Pull Request] [feat(trie): move leaf short keys into values HashMap](https://github.com/paradigmxyz/reth/pull/21857) - 2026-02-05
+* [Pull Request] [perf(prewarm): disable balance check for prewarming transactions](https://github.com/paradigmxyz/reth/pull/21941) - 2026-02-07
+* [Pull Request] [feat(rpc): add `subscribeFinalizedChainNotifications` endpoint](https://github.com/paradigmxyz/reth/pull/22011) - 2026-02-09
 * [Issue] [Implement variants for BAL devp2p variants](https://github.com/paradigmxyz/reth/issues/22015) - 2026-02-10
-* [Pull Request] []() - 2026-02-14
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [fix: remove unused `RangeBounds` import in storage-api](https://github.com/paradigmxyz/reth/pull/22176) - 2026-02-14
+* [Pull Request] [fix(rpc): simplify error wrapping in AtBlockHash filter path](https://github.com/paradigmxyz/reth/pull/22286) - 2026-02-17
+* [Pull Request] [refactor: replace TryFrom*Response traits with unified RpcResponseConverter](https://github.com/paradigmxyz/reth/pull/22320) - 2026-02-18
 * [Issue] [Improve txcount binary search](https://github.com/paradigmxyz/reth/issues/22561) - 2026-02-25
 * [Issue] [feat(net): add BlockAccessListsClient trait and p2p BAL downloading (eth/71)](https://github.com/paradigmxyz/reth/issues/22593) - 2026-02-26
 * [Issue] [feat(net): add ReceiptsClient trait and p2p receipt downloading](https://github.com/paradigmxyz/reth/issues/22591) - 2026-02-26
-* [Pull Request] []() - 2026-03-08
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [docs: fix typos and grammar errors across crates](https://github.com/paradigmxyz/reth/pull/22877) - 2026-03-08
+* [Pull Request] [fix(op): implement is_system_tx for OpTxEnvelope](https://github.com/paradigmxyz/reth/pull/22882) - 2026-03-09
+* [Issue] [feat(payload): maintain block hash cache across payload builds](https://github.com/paradigmxyz/reth/issues/22913) - 2026-03-10
 [bluealloy/revm](https://github.com/bluealloy/revm)
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [feat(database): add storage getter to BundleState](https://github.com/bluealloy/revm/pull/3321) - 2026-01-16
+* [Pull Request] [feat: add BAL (Block Access List) example](https://github.com/bluealloy/revm/pull/3339) - 2026-01-21
 
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [feat(database): add clear() to CacheState and TransitionState](https://github.com/bluealloy/revm/pull/3390) - 2026-02-01
+* [Pull Request] [feat: add `extend` method to `BlockHashCache`](https://github.com/bluealloy/revm/pull/3471) - 2026-03-03
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2026-01-24
+* [Pull Request] [fix(engine): use correct error codes for invalid payload attributes](https://github.com/ethereum/hive/pull/1383) - 2026-01-24
 
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2026-01-25
+* [Pull Request] [test(debug_getRawReceipts): use post-Byzantium block for get-block-n test](https://github.com/ethereum/execution-apis/pull/742) - 2026-01-25
 ## Q4 2025
 
 
@@ -83,7 +84,7 @@ Team: Reth
 * [Issue] [support batch rpc calls in historical forwarding](https://github.com/paradigmxyz/reth/issues/19677) - 2025-11-12
 * [Issue] [Replace std rwlock with parkinglot](https://github.com/paradigmxyz/reth/issues/19770) - 2025-11-14
 * [Pull Request] []() - 2025-11-15
-* [Pull Request] []() - 2025-11-17
+* [Pull Request] [fix: remove bad reset and cancel on drop](https://github.com/paradigmxyz/reth/pull/19821) - 2025-11-17
 * [Issue] [Replace opreceipt with alloy's](https://github.com/paradigmxyz/reth/issues/19838) - 2025-11-18
 * [Issue] [replace op-reth OpReceipt with op-alloy's](https://github.com/paradigmxyz/reth/issues/19837) - 2025-11-18
 * [Issue] [Replace OpReceipt with alloy's](https://github.com/paradigmxyz/reth/issues/19839) - 2025-11-18
@@ -93,26 +94,26 @@ Team: Reth
 * [Issue] [Add TransactionPoolExt::filter_pooled_txs(Fn(&) -> bool)](https://github.com/paradigmxyz/reth/issues/19919) - 2025-11-23
 * [Issue] [Introduce PayloadValidator::payload_to_block](https://github.com/paradigmxyz/reth/issues/19949) - 2025-11-24
 * [Issue] [Move CliHeader to primitives traits and rename to HeaderMut](https://github.com/paradigmxyz/reth/issues/20000) - 2025-11-26
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-11-28
+* [Pull Request] [fix(net): back off slightly after graceful connection termination](https://github.com/paradigmxyz/reth/pull/20020) - 2025-11-27
+* [Pull Request] [chore: add elapsed info to logs](https://github.com/paradigmxyz/reth/pull/20035) - 2025-11-28
 * [Issue] [handle more dedicated ethsimulate rpc errors ](https://github.com/paradigmxyz/reth/issues/20054) - 2025-12-01
 * [Issue] [Improve error message for TransactionConversionError](https://github.com/paradigmxyz/reth/issues/20052) - 2025-12-01
 * [Issue] [Always encode txtype for receipts over p2p](https://github.com/paradigmxyz/reth/issues/20072) - 2025-12-02
 * [Issue] [Add support for testing_ rpc namespace and testing_buildBlockV1](https://github.com/paradigmxyz/reth/issues/20069) - 2025-12-02
-* [Pull Request] []() - 2025-12-03
+* [Pull Request] [chore: allow empty blobparams in ethconfig](https://github.com/paradigmxyz/reth/pull/20105) - 2025-12-03
 * [Issue] [avoid double account cache lookup](https://github.com/paradigmxyz/reth/issues/20145) - 2025-12-05
-* [Pull Request] []() - 2025-12-06
-* [Pull Request] []() - 2025-12-07
+* [Pull Request] [chore: featuer gate rocksdb](https://github.com/paradigmxyz/reth/pull/20170) - 2025-12-06
+* [Pull Request] [perf: avoid duplicate storage get call](https://github.com/paradigmxyz/reth/pull/20180) - 2025-12-07
 * [Issue] [Return error if toBlock exceeds the current height](https://github.com/paradigmxyz/reth/issues/20197) - 2025-12-08
 * [Issue] [Add support for debug_getBlockAccessList](https://github.com/paradigmxyz/reth/issues/20269) - 2025-12-10
 * [Issue] [Add BAL metrics types](https://github.com/paradigmxyz/reth/issues/20268) - 2025-12-10
-* [Pull Request] []() - 2025-12-12
+* [Pull Request] [fix: only collect already tracked accounts](https://github.com/paradigmxyz/reth/pull/20341) - 2025-12-12
 * [Issue] [Add hardfork activation event printout](https://github.com/paradigmxyz/reth/issues/20350) - 2025-12-13
 * [Issue] [Make write_block_bodies operate on &Body](https://github.com/paradigmxyz/reth/issues/20503) - 2025-12-18
-* [Pull Request] []() - 2025-12-23
-* [Pull Request] []() - 2025-12-24
-* [Pull Request] []() - 2025-12-28
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [chore: add metric for batch size](https://github.com/paradigmxyz/reth/pull/20610) - 2025-12-23
+* [Pull Request] [chore: ignore RUSTSEC-2025-0137](https://github.com/paradigmxyz/reth/pull/20633) - 2025-12-24
+* [Pull Request] [perf(trie): add FromIterator for HashedPostState and simplify from_bundle_state](https://github.com/paradigmxyz/reth/pull/20653) - 2025-12-28
+* [Pull Request] [perf: pre-alloc removed vec](https://github.com/paradigmxyz/reth/pull/20679) - 2025-12-30
 * [Issue] [Optimize  send_raw_transaction_sync receipts fetching](https://github.com/paradigmxyz/reth/issues/20681) - 2025-12-30
 * [Issue] [Optimize evm_env if header is available](https://github.com/paradigmxyz/reth/issues/20690) - 2025-12-31
 ## Q3 2025

--- a/members/mattsse.md
+++ b/members/mattsse.md
@@ -36,6 +36,14 @@ Team: Reth
 * [Pull Request] [docs: fix typos and grammar errors across crates](https://github.com/paradigmxyz/reth/pull/22877) - 2026-03-08
 * [Pull Request] [fix(op): implement is_system_tx for OpTxEnvelope](https://github.com/paradigmxyz/reth/pull/22882) - 2026-03-09
 * [Issue] [feat(payload): maintain block hash cache across payload builds](https://github.com/paradigmxyz/reth/issues/22913) - 2026-03-10
+* [Review] [Review on: perf(provider): drop clones before to_plain_state_reverts](https://github.com/paradigmxyz/reth/pull/22918#pullrequestreview-3923625473) - 2026-03-10
+* [Review] [Review on: perf(engine): offload DeferredDrops deallocation to a persistent background thread](https://github.com/paradigmxyz/reth/pull/22908#pullrequestreview-3921435317) - 2026-03-10
+* [Review] [Review on: feat(rpc): add operator RPC server (`--operator`)](https://github.com/paradigmxyz/reth/pull/22887#pullrequestreview-3921512492) - 2026-03-10
+* [Review] [Review on: fix(rpc): disable EIP-7825 tx gas limit cap in eth_createAccessList and eth_estimateGas](https://github.com/paradigmxyz/reth/pull/22893#pullrequestreview-3920576554) - 2026-03-10
+* [Review] [Review on: fix(rpc): disable EIP-7825 tx gas limit cap in eth_createAccessList and eth_estimateGas](https://github.com/paradigmxyz/reth/pull/22893#pullrequestreview-3920579871) - 2026-03-10
+* [Review] [Review on: fix(rpc): disable EIP-7825 tx gas limit cap in eth_createAccessList and eth_estimateGas](https://github.com/paradigmxyz/reth/pull/22893#pullrequestreview-3920580871) - 2026-03-10
+* [Review] [Review on: refactor(txpool): change `EthTransactionValidator::validate_stateless` return type, accept tx by ref](https://github.com/paradigmxyz/reth/pull/22910#pullrequestreview-3921091547) - 2026-03-10
+* [Review] [Review on: perf(provider): remove unnecessary clones in changeset readers](https://github.com/paradigmxyz/reth/pull/22906#pullrequestreview-3921106432) - 2026-03-10
 [bluealloy/revm](https://github.com/bluealloy/revm)
 * [Pull Request] [feat(database): add storage getter to BundleState](https://github.com/bluealloy/revm/pull/3321) - 2026-01-16
 * [Pull Request] [feat: add BAL (Block Access List) example](https://github.com/bluealloy/revm/pull/3339) - 2026-01-21

--- a/members/mattsse.md
+++ b/members/mattsse.md
@@ -35,6 +35,7 @@ Team: Reth
 * [Issue] [feat(net): add ReceiptsClient trait and p2p receipt downloading](https://github.com/paradigmxyz/reth/issues/22591) - 2026-02-26
 * [Pull Request] []() - 2026-03-08
 * [Pull Request] []() - 2026-03-09
+* [Issue] [feat(payload): maintain block hash cache across payload builds](https://github.com/paradigmxyz/reth/issues/22913) - 2026-03-10
 [bluealloy/revm](https://github.com/bluealloy/revm)
 * [Pull Request] []() - 2026-01-16
 * [Pull Request] []() - 2026-01-21

--- a/members/maximmenshikov.md
+++ b/members/maximmenshikov.md
@@ -10,4 +10,4 @@ Github: [@maximmenshikov](https://github.com/maximmenshikov)
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Use modern libziskos and implement canonical way to reference precompiles](https://github.com/NethermindEth/nethermind/pull/10755) - 2026-03-09

--- a/members/mehdi-aouadi.md
+++ b/members/mehdi-aouadi.md
@@ -12,18 +12,25 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Amehdi-
 
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [update copyright year](https://github.com/Consensys/teku/pull/10300) - 2026-01-26
+* [Pull Request] [downgrade snappy-java to 1.1.10.7 because of the musl detection issue](https://github.com/Consensys/teku/pull/10289) - 2026-01-27
+* [Pull Request] [10146 gloas execution payload gossip rules](https://github.com/Consensys/teku/pull/10168) - 2026-01-28
+* [Pull Request] [10175 execution payload bid gloas gossip](https://github.com/Consensys/teku/pull/10198) - 2026-01-31
+* [Pull Request] [Use current date when CI triggered manually](https://github.com/Consensys/teku/pull/10328) - 2026-02-04
 * [Issue] [Add getNodeVersionV2](https://github.com/Consensys/teku/issues/10350) - 2026-02-09
 * [Issue] [Update AbstractDataColumnSidecarValidator for Gloas](https://github.com/Consensys/teku/issues/10349) - 2026-02-09
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [10176 gloas dcsc gossip](https://github.com/Consensys/teku/pull/10299) - 2026-02-10
+* [Pull Request] [update data column sidecars by range RPC for Gloas](https://github.com/Consensys/teku/pull/10429) - 2026-02-26
 * [Issue] [Gloas Attestation index](https://github.com/Consensys/teku/issues/10439) - 2026-03-02
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [update data column by range test for gloas](https://github.com/Consensys/teku/pull/10442) - 2026-03-03
+* [Pull Request] [bundle ref tests](https://github.com/Consensys/teku/pull/10460) - 2026-03-06
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [10259 proposer preferences gossip](https://github.com/Consensys/teku/pull/10472) - 2026-03-10
+* [Pull Request] [ci cleanup](https://github.com/Consensys/teku/pull/10466) - 2026-03-10
+* [Pull Request] [add proposer preferences container](https://github.com/Consensys/teku/pull/10467) - 2026-03-10
+* [Commit] [ci cleanup (#10466)](https://github.com/Consensys/teku/commit/f5c963b99f9ea70192a1535d728db5a22c218065) - 2026-03-10
+* [Commit] [add proposer preferences container (#10467)](https://github.com/Consensys/teku/commit/5669598367dfe187f345e0530cabda7c7d4a8896) - 2026-03-10
 ## Q4 2025
 
 
@@ -31,19 +38,19 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Amehdi-
 * [Pull Request] [add no-op bls signature verifier](https://github.com/Consensys/teku/pull/9953) - 2025-10-01
 * [Pull Request] [Revert "Focil gloas"](https://github.com/Consensys/teku/pull/9952) - 2025-10-01
 * [Issue] [Update GetAttestationData for Electra](https://github.com/Consensys/teku/issues/9993) - 2025-10-10
-* [Pull Request] []() - 2025-10-21
+* [Pull Request] [gloas beacon_block gossip rules](https://github.com/Consensys/teku/pull/10040) - 2025-10-21
 * [Issue] [Gloas beacon_attestation gossip rules](https://github.com/Consensys/teku/issues/10065) - 2025-10-28
 * [Issue] [Gloas beacon_block gossip rules](https://github.com/Consensys/teku/issues/10064) - 2025-10-28
-* [Pull Request] []() - 2025-11-14
+* [Pull Request] [add Gloas block gossip validation rules](https://github.com/Consensys/teku/pull/10140) - 2025-11-14
 * [Issue] [Gloas execution_payload gossip rules](https://github.com/Consensys/teku/issues/10146) - 2025-11-17
 
 * [Pull Request] []() - 2025-11-24
 * [Issue] [Network configuration unit test downloading config from the web](https://github.com/Consensys/teku/issues/10195) - 2025-12-01
 * [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [replace LRUCache with CaffeineCache](https://github.com/Consensys/teku/pull/10225) - 2025-12-11
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-11-19
-* [Pull Request] []() - 2025-11-25
+* [Pull Request] [Fix gloas `execution_payload` gossip rules typo](https://github.com/ethereum/consensus-specs/pull/4751) - 2025-11-19
+* [Pull Request] [Fix block gossip rule typo](https://github.com/ethereum/consensus-specs/pull/4760) - 2025-11-25
 ## Q3 2025
 
 

--- a/members/mehdi-aouadi.md
+++ b/members/mehdi-aouadi.md
@@ -31,6 +31,8 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Amehdi-
 * [Pull Request] [add proposer preferences container](https://github.com/Consensys/teku/pull/10467) - 2026-03-10
 * [Commit] [ci cleanup (#10466)](https://github.com/Consensys/teku/commit/f5c963b99f9ea70192a1535d728db5a22c218065) - 2026-03-10
 * [Commit] [add proposer preferences container (#10467)](https://github.com/Consensys/teku/commit/5669598367dfe187f345e0530cabda7c7d4a8896) - 2026-03-10
+* [Review] [Review on: Update DB migration according to the current state (main direction of migration LevelDB -> RocksDB)](https://github.com/Consensys/teku/pull/10471#pullrequestreview-3923655061) - 2026-03-10
+* [Review] [Review on: add proposer preferences container](https://github.com/Consensys/teku/pull/10467#pullrequestreview-3920807264) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/mh0lt.md
+++ b/members/mh0lt.md
@@ -47,6 +47,7 @@ Team: Erigon
 * [Issue] [IBS 2-Cache Phase 3: Fix timing hole; eliminate rs.accounts](https://github.com/erigontech/erigon/issues/19702) - 2026-03-06
 * [Issue] [IBS 2-Cache Phase 2: Derive StateUpdates directly from VersionedWrites](https://github.com/erigontech/erigon/issues/19701) - 2026-03-06
 * [Issue] [IBS 2-Cache Phase 1: Establish test baseline](https://github.com/erigontech/erigon/issues/19700) - 2026-03-06
+* [Pull Request] []() - 2026-03-11
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
 * [Pull Request] []() - 2026-02-13
 ## Q4 2025

--- a/members/mh0lt.md
+++ b/members/mh0lt.md
@@ -55,6 +55,8 @@ Team: Erigon
 * [Commit] [execution/state: fix WriteAccountStorage skip using stale blockOriginStorage (#19748)](https://github.com/erigontech/erigon/commit/4f7caee2a467a902a778cce3579d0bbae7a3693a) - 2026-03-10
 * [Commit] [execution/stagedsync: enable deferred commitment updates for parallel fork validation (#19749)](https://github.com/erigontech/erigon/commit/2ad804246f4787896888cd5c1c5b5c3dfcfed911) - 2026-03-10
 * [Commit] [Remove unused 'isBlockProduction' from ExecV3 (#19760)](https://github.com/erigontech/erigon/commit/495b946f5484d7f7489bfbf05bb7b01e2feac35a) - 2026-03-10
+* [Review] [Review on: vm: fix CREATE/CREATE2 collision with EIP-7702 delegated accounts](https://github.com/erigontech/erigon/pull/19777#pullrequestreview-3924380241) - 2026-03-10
+* [Review] [Review on: txpool: penalize peers sending malformed p2p messages](https://github.com/erigontech/erigon/pull/19781#pullrequestreview-3924372755) - 2026-03-10
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
 * [Pull Request] [Add null slotnumber to erigon_ api](https://github.com/erigontech/rpc-tests/pull/523) - 2026-02-13
 ## Q4 2025

--- a/members/mh0lt.md
+++ b/members/mh0lt.md
@@ -12,16 +12,16 @@ Team: Erigon
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-17
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-07
+* [Pull Request] [Add invalid block marker for hive](https://github.com/erigontech/erigon/pull/18634) - 2026-01-12
+* [Pull Request] [Invalid block execution fixes](https://github.com/erigontech/erigon/pull/18706) - 2026-01-17
+* [Pull Request] [Fix Failing Non List Validation Hive Tests](https://github.com/erigontech/erigon/pull/18666) - 2026-01-29
+* [Pull Request] [Parallel short tests fixes](https://github.com/erigontech/erigon/pull/18914) - 2026-02-07
 
-* [Pull Request] []() - 2026-02-14
+* [Pull Request] [ Add EIP-7843: SLOTNUM implementation](https://github.com/erigontech/erigon/pull/19147) - 2026-02-14
 * [Issue] [Remove TxNum & BlockNum from SharedDomains](https://github.com/erigontech/erigon/issues/19289) - 2026-02-18
 * [Issue] [Remove ExecV3 from SpawnBuilderExecStage](https://github.com/erigontech/erigon/issues/19318) - 2026-02-19
 * [Issue] [Remove Silkworm support from codebase](https://github.com/erigontech/erigon/issues/19403) - 2026-02-22
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [Fix/bal selfdestruct netzero](https://github.com/erigontech/erigon/pull/19528) - 2026-02-27
 * [Issue] [Refactor execution module gRPC interface to plain Go interface](https://github.com/erigontech/erigon/issues/19527) - 2026-02-27
 * [Issue] [Downloader: missing torrent metadata for old files can block node startup, or cuase confusing logging](https://github.com/erigontech/erigon/issues/19545) - 2026-03-01
 * [Issue] [BAL Related Performance Evaluation](https://github.com/erigontech/erigon/issues/19589) - 2026-03-03
@@ -47,8 +47,16 @@ Team: Erigon
 * [Issue] [IBS 2-Cache Phase 3: Fix timing hole; eliminate rs.accounts](https://github.com/erigontech/erigon/issues/19702) - 2026-03-06
 * [Issue] [IBS 2-Cache Phase 2: Derive StateUpdates directly from VersionedWrites](https://github.com/erigontech/erigon/issues/19701) - 2026-03-06
 * [Issue] [IBS 2-Cache Phase 1: Establish test baseline](https://github.com/erigontech/erigon/issues/19700) - 2026-03-06
+* [Pull Request] [claude: add CI test skills (unit, all, race, hive, rpc, ci-orchestrator)](https://github.com/erigontech/erigon/pull/19784) - 2026-03-10
+* [Pull Request] [execution/state: regression test for originStorage A→B→A skip bug (follow-up to #19748)](https://github.com/erigontech/erigon/pull/19776) - 2026-03-10
+* [Pull Request] [execution/state: fix WriteAccountStorage skip using stale blockOriginStorage](https://github.com/erigontech/erigon/pull/19748) - 2026-03-10
+* [Pull Request] [execution/stagedsync: enable deferred commitment updates for parallel fork validation](https://github.com/erigontech/erigon/pull/19749) - 2026-03-10
+* [Commit] [claude: add CI test skills (unit, all, race, hive, rpc, ci-orchestrator) (#19784)](https://github.com/erigontech/erigon/commit/f7e672af3151c7a764ccb2085b03a06602be4cea) - 2026-03-11
+* [Commit] [execution/state: fix WriteAccountStorage skip using stale blockOriginStorage (#19748)](https://github.com/erigontech/erigon/commit/4f7caee2a467a902a778cce3579d0bbae7a3693a) - 2026-03-10
+* [Commit] [execution/stagedsync: enable deferred commitment updates for parallel fork validation (#19749)](https://github.com/erigontech/erigon/commit/2ad804246f4787896888cd5c1c5b5c3dfcfed911) - 2026-03-10
+* [Commit] [Remove unused 'isBlockProduction' from ExecV3 (#19760)](https://github.com/erigontech/erigon/commit/495b946f5484d7f7489bfbf05bb7b01e2feac35a) - 2026-03-10
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [Add null slotnumber to erigon_ api](https://github.com/erigontech/rpc-tests/pull/523) - 2026-02-13
 ## Q4 2025
 
 
@@ -83,7 +91,7 @@ Team: Erigon
 * [Issue] [Improve Block Production Uint Tests](https://github.com/erigontech/erigon/issues/17508) - 2025-10-16
 * [Issue] [NewPayload spam for slots with invalid blocks](https://github.com/erigontech/erigon/issues/17505) - 2025-10-16
 * [Issue] [Consolidate Mining Execution](https://github.com/erigontech/erigon/issues/17529) - 2025-10-17
-* [Pull Request] []() - 2025-12-25
+* [Pull Request] [Add block reader to trace block initializer](https://github.com/erigontech/erigon/pull/18459) - 2025-12-25
 ## Q3 2025
 
 

--- a/members/michaelsproul.md
+++ b/members/michaelsproul.md
@@ -33,6 +33,8 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amich
 * [Issue] [Gloas: cold DB](https://github.com/sigp/lighthouse/issues/8958) - 2026-03-10
 * [Issue] [Gloas: `get_expected_withdrawals`/fcU interaction with Full/Empty blocks](https://github.com/sigp/lighthouse/issues/8957) - 2026-03-10
 * [Issue] [Gloas: track head envelope in `canonical_head`](https://github.com/sigp/lighthouse/issues/8956) - 2026-03-10
+* [Issue] [Gloas: state reconstruction](https://github.com/sigp/lighthouse/issues/8962) - 2026-03-10
+* [Issue] [Gloas: payload envelope in `PreProcessingSnapshot`](https://github.com/sigp/lighthouse/issues/8961) - 2026-03-10
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Issue] [Operations test docs are out of date](https://github.com/ethereum/consensus-specs/issues/4912) - 2026-02-11
 * [Issue] [Add payload attestations to `sanity/blocks` tests for Gloas](https://github.com/ethereum/consensus-specs/issues/4929) - 2026-02-16

--- a/members/michaelsproul.md
+++ b/members/michaelsproul.md
@@ -38,6 +38,16 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amich
 * [Pull Request] [Start on Gloas reference in book](https://github.com/sigp/lighthouse/pull/8964) - 2026-03-10
 * [Issue] [Gloas: state reconstruction](https://github.com/sigp/lighthouse/issues/8962) - 2026-03-10
 * [Issue] [Gloas: payload envelope in `PreProcessingSnapshot`](https://github.com/sigp/lighthouse/issues/8961) - 2026-03-10
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926118977) - 2026-03-10
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926145358) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926159292) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926169021) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926219210) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926220437) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926236215) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926256260) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926260432) - 2026-03-11
+* [Review] [Review on: Optionally check DB invariants at runtime](https://github.com/sigp/lighthouse/pull/8952#pullrequestreview-3926269299) - 2026-03-11
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Issue] [Operations test docs are out of date](https://github.com/ethereum/consensus-specs/issues/4912) - 2026-02-11
 * [Issue] [Add payload attestations to `sanity/blocks` tests for Gloas](https://github.com/ethereum/consensus-specs/issues/4929) - 2026-02-16

--- a/members/michaelsproul.md
+++ b/members/michaelsproul.md
@@ -12,27 +12,32 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amich
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [Remove merge code](https://github.com/sigp/lighthouse/pull/8658) - 2026-01-14
 * [Issue] [Sync committee messages have to wait for full block import](https://github.com/sigp/lighthouse/issues/8667) - 2026-01-15
 * [Issue] [Gloas fork choice implementation](https://github.com/sigp/lighthouse/issues/8675) - 2026-01-19
 * [Issue] [Release v8.1.0](https://github.com/sigp/lighthouse/issues/8681) - 2026-01-20
 * [Issue] [Gloas devnet planning](https://github.com/sigp/lighthouse/issues/8680) - 2026-01-20
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [Fast path for `/eth/v1/beacon/blocks/head/root`](https://github.com/sigp/lighthouse/pull/8729) - 2026-02-02
+* [Pull Request] [Run all ssz_static tests for Gloas](https://github.com/sigp/lighthouse/pull/8755) - 2026-02-04
 * [Issue] [Allow LH to build without OpenSSL](https://github.com/sigp/lighthouse/issues/8756) - 2026-02-04
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [Merge v8.1.0 (stable) into unstable](https://github.com/sigp/lighthouse/pull/8778) - 2026-02-09
+* [Pull Request] [Gloas envelope consensus and more operations tests](https://github.com/sigp/lighthouse/pull/8781) - 2026-02-10
 * [Issue] [Blob delay is always "unknown" in head block logs](https://github.com/sigp/lighthouse/issues/8775) - 2026-02-09
 
 * [Issue] [Regression in `DataColumnsByRange` responses (duplicates included)](https://github.com/sigp/lighthouse/issues/8842) - 2026-02-18
 * [Issue] [Test new allocators (mimalloc, tcmalloc)](https://github.com/sigp/lighthouse/issues/8840) - 2026-02-18
 * [Issue] [Gloas state storage design](https://github.com/sigp/lighthouse/issues/8893) - 2026-02-24
-* [Pull Request] []() - 2026-03-01
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Back merge v8.1.1](https://github.com/sigp/lighthouse/pull/8917) - 2026-03-01
+* [Pull Request] [Remove `/lighthouse/analysis/block_rewards` APIs](https://github.com/sigp/lighthouse/pull/8935) - 2026-03-09
 * [Issue] [Gloas: re-enable late block reorgs](https://github.com/sigp/lighthouse/issues/8959) - 2026-03-10
 * [Issue] [Gloas: cold DB](https://github.com/sigp/lighthouse/issues/8958) - 2026-03-10
 * [Issue] [Gloas: `get_expected_withdrawals`/fcU interaction with Full/Empty blocks](https://github.com/sigp/lighthouse/issues/8957) - 2026-03-10
 * [Issue] [Gloas: track head envelope in `canonical_head`](https://github.com/sigp/lighthouse/issues/8956) - 2026-03-10
+* [Pull Request] [Implement proposer duties v2 endpoint](https://github.com/sigp/lighthouse/pull/8918) - 2026-03-10
+* [Pull Request] [Back merge 8.1.2](https://github.com/sigp/lighthouse/pull/8963) - 2026-03-10
+* [Pull Request] [Start on Gloas reference in book](https://github.com/sigp/lighthouse/pull/8964) - 2026-03-10
+* [Issue] [Gloas: state reconstruction](https://github.com/sigp/lighthouse/issues/8962) - 2026-03-10
+* [Issue] [Gloas: payload envelope in `PreProcessingSnapshot`](https://github.com/sigp/lighthouse/issues/8961) - 2026-03-10
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Issue] [Operations test docs are out of date](https://github.com/ethereum/consensus-specs/issues/4912) - 2026-02-11
 * [Issue] [Add payload attestations to `sanity/blocks` tests for Gloas](https://github.com/ethereum/consensus-specs/issues/4929) - 2026-02-16
@@ -49,19 +54,19 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amich
 * [Commit] [Persist only custody columns in db (#8188)](https://github.com/sigp/lighthouse/commit/2c328e32a6cd139c0c6ee44b99a5e0ab8e7ebe59) - 2025-10-13
 * [Issue] [CLI flag for "semi-supernode"](https://github.com/sigp/lighthouse/issues/8218) - 2025-10-16
 * [Issue] [Remember non-canonical block roots](https://github.com/sigp/lighthouse/issues/8216) - 2025-10-16
-* [Pull Request] []() - 2025-10-20
+* [Pull Request] [Allow get_beacon_proposer_index at next epoch](https://github.com/sigp/lighthouse/pull/8235) - 2025-10-20
 * [Issue] [Custody info API](https://github.com/sigp/lighthouse/issues/8249) - 2025-10-21
 * [Issue] [Reduce spurious recompilation due to `lighthouse_version`](https://github.com/sigp/lighthouse/issues/8311) - 2025-10-28
 * [Issue] [Cargo update before v8.1.0](https://github.com/sigp/lighthouse/issues/8346) - 2025-11-03
-* [Pull Request] []() - 2025-11-03
-* [Pull Request] []() - 2025-11-06
+* [Pull Request] [Optimise `state_root_at_slot` for finalized slot](https://github.com/sigp/lighthouse/pull/8353) - 2025-11-03
+* [Pull Request] [Optimise fork choice attestation dequeueing](https://github.com/sigp/lighthouse/pull/8378) - 2025-11-06
 * [Issue] [Run `cargo deny` or similar on CI](https://github.com/sigp/lighthouse/issues/8408) - 2025-11-13
-* [Pull Request] []() - 2025-11-17
+* [Pull Request] [Fix tracing span for execution payload verif](https://github.com/sigp/lighthouse/pull/8419) - 2025-11-17
 * [Issue] [Investigate not pruning the split block's payload](https://github.com/sigp/lighthouse/issues/8431) - 2025-11-19
-* [Pull Request] []() - 2025-11-24
+* [Pull Request] [Consolidate reqwest versions](https://github.com/sigp/lighthouse/pull/8452) - 2025-11-24
 
 * [Issue] [Reduce number of `spawn`s in VC attestation service](https://github.com/sigp/lighthouse/issues/8520) - 2025-12-03
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [Move deposit contract artifacts to /target](https://github.com/sigp/lighthouse/pull/8518) - 2025-12-02
 * [Issue] [Gloas TODO tracking issue](https://github.com/sigp/lighthouse/issues/8590) - 2025-12-16
 * [Issue] [Remove `GloasNotImplemented` error once Gloas is implemented](https://github.com/sigp/lighthouse/issues/8589) - 2025-12-16
 * [Issue] [Update beacon block streamer tests for Gloas](https://github.com/sigp/lighthouse/issues/8588) - 2025-12-16

--- a/members/misilva73.md
+++ b/members/misilva73.md
@@ -15,4 +15,4 @@ Github: [@misilva73](https://github.com/misilva73)
 * [Issue] [Glamsterdam Repricings #2, Feb 18, 2026](https://github.com/ethereum/pm/issues/1935) - 2026-02-18
 * [Issue] [Glamsterdam Repricings #3, Mar 4, 2026](https://github.com/ethereum/pm/issues/1959) - 2026-03-04
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [Update EIP-8037: Add quantization, reservoir model, and refine gas accounting](https://github.com/ethereum/EIPs/pull/11292) - 2026-02-09

--- a/members/mjfh.md
+++ b/members/mjfh.md
@@ -12,21 +12,21 @@ Team: Nimbus
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [Update p2p protocol packing](https://github.com/status-im/nimbus-eth1/pull/3896) - 2026-01-07
+* [Pull Request] [Snap sync packet proofs](https://github.com/status-im/nimbus-eth1/pull/3935) - 2026-01-27
+* [Pull Request] [Snap sync provide assembly db api](https://github.com/status-im/nimbus-eth1/pull/3949) - 2026-01-30
+* [Pull Request] [Snap sync maint update](https://github.com/status-im/nimbus-eth1/pull/3969) - 2026-02-06
+* [Pull Request] [Snap sync implement code dowloader](https://github.com/status-im/nimbus-eth1/pull/3982) - 2026-02-15
+* [Pull Request] [Snap sync perpare assembly db for mpt import](https://github.com/status-im/nimbus-eth1/pull/4029) - 2026-03-02
 ## Q4 2025
 
 
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
 * [Commit] [Beacon sync timing and maint update (#3761)](https://github.com/status-im/nimbus-eth1/commit/163251618e61e1b23d017796229c007d0d8dae0e) - 2025-10-10
-* [Pull Request] []() - 2025-11-20
-* [Pull Request] []() - 2025-11-24
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-19
+* [Pull Request] [Beacon sync trace replay test tools v3](https://github.com/status-im/nimbus-eth1/pull/3837) - 2025-11-20
+* [Pull Request] [Update pending and finalised registry](https://github.com/status-im/nimbus-eth1/pull/3844) - 2025-11-24
+* [Pull Request] [Beacon sync maint update](https://github.com/status-im/nimbus-eth1/pull/3867) - 2025-12-08
+* [Pull Request] [Beacon sync trace replay test tools v4](https://github.com/status-im/nimbus-eth1/pull/3885) - 2025-12-19
 ## Q3 2025
 
 

--- a/members/mkalinin.md
+++ b/members/mkalinin.md
@@ -14,14 +14,14 @@ Team: [ethresearch](https://ethresear.ch/u/mkalinin), [hackmd](https://hackmd.io
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
 * [Commit] [Add Amsterdam execution-api specs (#691)](https://github.com/ethereum/execution-apis/commit/4ec8e5735ebb3f2ce0702726385cdde70034f78c) - 2025-10-06
 
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-08
+* [Pull Request] [engine: Simplify wording for BAL validation failure](https://github.com/ethereum/execution-apis/pull/714) - 2025-12-05
+* [Pull Request] [engine: Delete eip7928](https://github.com/ethereum/execution-apis/pull/715) - 2025-12-08
 * [Pull Request] []() - 2025-12-15
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-30
+* [Pull Request] [Add EIP: Prevent using consolidations as withdrawals](https://github.com/ethereum/EIPs/pull/10656) - 2025-10-30
 
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-11-18
+* [Pull Request] [Fast Confirmation Rule](https://github.com/ethereum/consensus-specs/pull/4747) - 2025-11-18
 ## Q3 2025
 
 

--- a/members/mriccobene.md
+++ b/members/mriccobene.md
@@ -12,7 +12,8 @@ Team: Erigon
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-30
+* [Pull Request] [qa-tests: RPC integration test (latest) fast failure](https://github.com/erigontech/erigon/pull/18900) - 2026-01-30
+* [Pull Request] [qa-tests: fix fd-leak-analysis artifact name in 'sync with external cl' test](https://github.com/erigontech/erigon/pull/19775) - 2026-03-10
 ## Q4 2025
 
 
@@ -30,19 +31,19 @@ Team: Erigon
 * [Issue] [Unfinished execution history download on Chiado](https://github.com/erigontech/erigon/issues/17590) - 2025-10-22
 * [Issue] [Improve Tip-Tracking test with more debug tools](https://github.com/erigontech/erigon/issues/17646) - 2025-10-24
 * [Issue] [[EngineBlockDownloader] could not process backward download request](https://github.com/erigontech/erigon/issues/17681) - 2025-10-27
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [qa-tests: add profiling data upload to the tip-tracking with load test](https://github.com/erigontech/erigon/pull/17697) - 2025-10-28
 * [Issue] [Sync issue on Hoodi: "Failed to process block batch"](https://github.com/erigontech/erigon/issues/17731) - 2025-10-31
 * [Issue] [RPC integration tests: update pre-built dbs](https://github.com/erigontech/erigon/issues/17779) - 2025-11-04
 * [Issue] [tip-tracking tests: add more info and debugging tools](https://github.com/erigontech/erigon/issues/17786) - 2025-11-05
-* [Pull Request] []() - 2025-11-10
+* [Pull Request] [qa-tests: use the latest version of the Lighthouse client in sync-with-externalcl test](https://github.com/erigontech/erigon/pull/17848) - 2025-11-10
 * [Issue] [Tip-Tracking w/ load: fix](https://github.com/erigontech/erigon/issues/17841) - 2025-11-10
-* [Pull Request] []() - 2025-11-18
+* [Pull Request] [qa-tests: remove unnecessary downgrade procedure from tip-tracking tests](https://github.com/erigontech/erigon/pull/17950) - 2025-11-18
 * [Issue] [Investigate Erigon crash on recent RPC perf test](https://github.com/erigontech/erigon/issues/17975) - 2025-11-19
 * [Issue] [tip-tracking: detect Erigon inactivity and break the test](https://github.com/erigontech/erigon/issues/17994) - 2025-11-20
-* [Pull Request] []() - 2025-12-16
+* [Pull Request] [[r3.3] hive: temporarily use older hive commit to fix ci (#18302)](https://github.com/erigontech/erigon/pull/18315) - 2025-12-16
 
 [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests)
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [integration: add json report generation](https://github.com/erigontech/rpc-tests/pull/507) - 2025-12-18
 ## Q3 2025
 
 

--- a/members/nalepae.md
+++ b/members/nalepae.md
@@ -12,10 +12,10 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Analepae)
 
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-02
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Summarize "Accepted data column sidecars summary" log.](https://github.com/OffchainLabs/prysm/pull/16210) - 2026-01-02
+* [Pull Request] [Add the `--disable-get-blobs-v2` flag and fixes #16171](https://github.com/OffchainLabs/prysm/pull/16155) - 2026-01-05
+* [Pull Request] [Implement parallel verification for KZG proofs in VerifyCellKZGProofBatch](https://github.com/OffchainLabs/prysm/pull/16220) - 2026-01-06
+* [Pull Request] [[POC] EIP-8025: Optional Execution Proofs](https://github.com/OffchainLabs/prysm/pull/16270) - 2026-01-21
 * [Issue] [No `Synced new block` log with INFO verbosity](https://github.com/OffchainLabs/prysm/issues/16314) - 2026-02-02
 * [Issue] [Do not copy the finalized state when computing validators custody requirements](https://github.com/OffchainLabs/prysm/issues/16354) - 2026-02-12
 * [Issue] [Extra memory consumed for unknown reason](https://github.com/OffchainLabs/prysm/issues/16376) - 2026-02-20
@@ -52,7 +52,7 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Analepae)
 * [Pull Request] [`VerifyDataColumnSidecar`: Check if there is no too many commitments.](https://github.com/OffchainLabs/prysm/pull/15859) - 2025-10-13
 * [Commit] [`VerifyDataColumnSidecar`: Check if there is no too many commitments.](https://github.com/OffchainLabs/prysm/commit/077428cb38dd9a60e72647e0666a8845e0f3c594) - 2025-10-13
 * [Commit] [`--subscribe-all-subnets`: Define it as an alias and define `--subscribe-all-attestations-and-sync-subnets` as the main value.](https://github.com/OffchainLabs/prysm/commit/c8b39bc59d37dbe374e1a1d9142e1cafe813a7a3) - 2025-10-13
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [Update go-netroute to `v0.3.0`](https://github.com/OffchainLabs/prysm/pull/15934) - 2025-10-27
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
 * [Issue] [Prysm broadcasts `0x000....` KZG proofs](https://github.com/OffchainLabs/prysm/issues/15958) - 2025-10-31
@@ -65,8 +65,8 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Analepae)
 * [Issue] [Optimize the volume needed for blob storage](https://github.com/OffchainLabs/prysm/issues/16133) - 2025-12-10
 * [Issue] [Compress not fully filled blobs in storage](https://github.com/OffchainLabs/prysm/issues/16132) - 2025-12-10
 * [Issue] [Lot of "replaying canonical blocks" using Prysm VC in REST mode](https://github.com/OffchainLabs/prysm/issues/16135) - 2025-12-11
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [Construct data column sidecars from the execution layer in parallel and add metrics](https://github.com/OffchainLabs/prysm/pull/16115) - 2025-12-16
+* [Pull Request] [Pending aggregates: When multiple aggregated attestations only differing by the aggregator index are in the pending queue, only process one of them.](https://github.com/OffchainLabs/prysm/pull/16153) - 2025-12-17
 ## Q3 2025
 
 

--- a/members/nazarhussain.md
+++ b/members/nazarhussain.md
@@ -13,11 +13,11 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
 * [Issue] [Use packages/cli/bin/lodesar for the binary execution path](https://github.com/ChainSafe/lodestar/issues/8755) - 2026-01-16
-* [Pull Request] []() - 2026-01-23
+* [Pull Request] [refactor: reuse state diff bytes logic](https://github.com/ChainSafe/lodestar/pull/8737) - 2026-01-23
 
 [chainsafe/lodestar-z](https://github.com/chainsafe/lodestar-z)
 * [Issue] [Use a performant and consistent allocator for all bindings](https://github.com/ChainSafe/lodestar-z/issues/220) - 2026-02-24
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [feat: error handling with error objects](https://github.com/ChainSafe/lodestar-z/pull/222) - 2026-03-03
 ## Q4 2025
 
 
@@ -26,9 +26,9 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Pull Request] [refactor: update the structure of state regen operation](https://github.com/ChainSafe/lodestar/pull/8509) - 2025-10-08
 * [Commit] [Squashed commit of the following:](https://github.com/ChainSafe/lodestar/commit/5c24ff62a4151479bee74896664ed30237e341d7) - 2025-10-08
 * [Commit] [feat: add xdelta3 support for computing binary difference (#7664)](https://github.com/ChainSafe/lodestar/commit/fd5ad2a8c85e1dd45b8dbcec7f446d617366e013) - 2025-10-08
-* [Pull Request] []() - 2025-11-19
+* [Pull Request] [test: enable `cli` and `beacon-node` unit tests for bun](https://github.com/ChainSafe/lodestar/pull/8617) - 2025-11-19
 * [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-10
+* [Pull Request] [chore: update publish workflow for rc an stan;e](https://github.com/ChainSafe/lodestar/pull/8686) - 2025-12-10
 ## Q3 2025
 
 

--- a/members/nazarhussain.md
+++ b/members/nazarhussain.md
@@ -18,6 +18,10 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 [chainsafe/lodestar-z](https://github.com/chainsafe/lodestar-z)
 * [Issue] [Use a performant and consistent allocator for all bindings](https://github.com/ChainSafe/lodestar-z/issues/220) - 2026-02-24
 * [Pull Request] [feat: error handling with error objects](https://github.com/ChainSafe/lodestar-z/pull/222) - 2026-03-03
+
+[ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
+* [Review] [Review on: chore: fix private imports](https://github.com/ChainSafe/lodestar/pull/8990#pullrequestreview-3922953406) - 2026-03-10
+* [Review] [Review on: feat: use tsgo for build and type checks](https://github.com/ChainSafe/lodestar/pull/8992#pullrequestreview-3922930927) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/nerolation.md
+++ b/members/nerolation.md
@@ -18,44 +18,46 @@ Team: [research](https://github.com/nerolation/pglanding-nerolation)
 * [Issue] [EIP-7928 Breakout #12, Feb 11, 2026](https://github.com/ethereum/pm/issues/1917) - 2026-02-09
 * [Issue] [EIP-7928 Breakout #13, Feb 25, 2026](https://github.com/ethereum/pm/issues/1944) - 2026-02-23
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [Update EIP-7778: correct license, improve wording](https://github.com/ethereum/EIPs/pull/11071) - 2026-01-13
+* [Pull Request] [Update EIP-7778: Clarify gas accounting for receipts](https://github.com/ethereum/EIPs/pull/11075) - 2026-01-14
 * [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-17
+* [Pull Request] [Update EIP-7778: add new receipt field for gas_spent](https://github.com/ethereum/EIPs/pull/11099) - 2026-01-17
 
 * [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-01
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [Update EIP-7928: Add first-accessed indices to BAL](https://github.com/ethereum/EIPs/pull/11181) - 2026-01-27
+* [Pull Request] [Update EIP-7928: clarify stf without BAL](https://github.com/ethereum/EIPs/pull/11227) - 2026-01-30
+* [Pull Request] [Update EIP-7928: cap max items in BAL](https://github.com/ethereum/EIPs/pull/11234) - 2026-02-01
+* [Pull Request] [Add EIP: eth/71 - Block Access List Exchange](https://github.com/ethereum/EIPs/pull/11307) - 2026-02-12
+* [Pull Request] [Update EIP-7773: Add EIP-7975 and EIP-8159 to the CFI list](https://github.com/ethereum/EIPs/pull/11319) - 2026-02-15
+* [Pull Request] [Update EIP-7928: simplify capping of block-level access list](https://github.com/ethereum/EIPs/pull/11323) - 2026-02-16
+* [Pull Request] [Update EIP-7976: update empirical report](https://github.com/ethereum/EIPs/pull/11326) - 2026-02-17
+* [Pull Request] [Update EIP-7928: Add Felipe, Rahul and Stefan as co-authors](https://github.com/ethereum/EIPs/pull/11392) - 2026-03-10
+* [Pull Request] [Add EIP: snap/2 - BAL-Based State Healing](https://github.com/ethereum/EIPs/pull/11391) - 2026-03-10
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2026-01-18
+* [Pull Request] [feat(tests): add worst-case BAL read test](https://github.com/ethereum/execution-specs/pull/2033) - 2026-01-18
 
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [feat(tests): add test case for create2 selfdestruct and recreate](https://github.com/ethereum/execution-specs/pull/2121) - 2026-02-06
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [engine: define EIP-7928 API methods](https://github.com/ethereum/execution-apis/pull/727) - 2026-02-04
+* [Pull Request] [eth: add EIP-7928 Block-level Access Lists JSON RPC methods](https://github.com/ethereum/execution-apis/pull/726) - 2026-03-02
 ## Q4 2025
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] [Update EIP-7928: Clarify EIP 7702](https://github.com/ethereum/EIPs/pull/10471) - 2025-10-04
 
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-19
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-11-18
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-04
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-25
+* [Pull Request] [Update EIP-7928: Clarify bal entry ordering](https://github.com/ethereum/EIPs/pull/10540) - 2025-10-14
+* [Pull Request] [Update EIP-7928: Clarify block reward wording again](https://github.com/ethereum/EIPs/pull/10573) - 2025-10-19
+* [Pull Request] [Update EIP-7976: Add empirical report with impact analysis](https://github.com/ethereum/EIPs/pull/10711) - 2025-11-04
+* [Pull Request] [Update EIP-7863: Fix spelling mistake](https://github.com/ethereum/EIPs/pull/10810) - 2025-11-18
+* [Pull Request] [Update EIP-7928: Clarify gas accounting sequence for BALs](https://github.com/ethereum/EIPs/pull/10866) - 2025-12-02
+* [Pull Request] [Update EIP-7778: Clarify receipts gas_used](https://github.com/ethereum/EIPs/pull/10872) - 2025-12-04
+* [Pull Request] [Update EIP-7928: Add updated BAL size analysis for 60M gas](https://github.com/ethereum/EIPs/pull/10887) - 2025-12-09
+* [Pull Request] [Update EIP-7928: Clarify system contract caller](https://github.com/ethereum/EIPs/pull/10895) - 2025-12-10
+* [Pull Request] [Update EIP-7928: Clarify initcode call](https://github.com/ethereum/EIPs/pull/10902) - 2025-12-11
+* [Pull Request] [Update EIP-7928: Fix analysis](https://github.com/ethereum/EIPs/pull/10910) - 2025-12-12
+* [Pull Request] [Update EIP-7928: change BAL retention period to WSP](https://github.com/ethereum/EIPs/pull/10940) - 2025-12-16
+* [Pull Request] [Update EIP-7928: Clarify wording around 7702](https://github.com/ethereum/EIPs/pull/10983) - 2025-12-25
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [EIP-7928 Breakout #4, Oct 24, 2025](https://github.com/ethereum/pm/issues/1755) - 2025-10-06
 * [Issue] [EIP-7928 Breakout #5, Oct 22, 2025](https://github.com/ethereum/pm/issues/1771) - 2025-10-20
@@ -65,13 +67,13 @@ Team: [research](https://github.com/nerolation/pglanding-nerolation)
 * [Issue] [EIP-7928 Breakout #8, Dec 3, 2025](https://github.com/ethereum/pm/issues/1822) - 2025-11-27
 * [Issue] [EIP-7928 Breakout #9, Dec 17, 2025](https://github.com/ethereum/pm/issues/1841) - 2025-12-10
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2025-10-31
-* [Pull Request] []() - 2025-11-01
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [feat(specs): EIP-7928 - Add gas used list to block access list](https://github.com/ethereum/execution-specs/pull/1723) - 2025-10-31
+* [Pull Request] [fix(specs): EIP-7928 - Refactor state.state_tracker argument pattern](https://github.com/ethereum/execution-specs/pull/1727) - 2025-11-01
+* [Pull Request] [fix(specs): EIP-7928 larger refactoring moving the state tracker and introduce check gas and charge gas sequence](https://github.com/ethereum/execution-specs/pull/1759) - 2025-11-05
 
-* [Pull Request] []() - 2025-12-31
+* [Pull Request] [feat(tests): add more 7928 test descriptions](https://github.com/ethereum/execution-specs/pull/1815) - 2025-12-31
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2025-12-13
+* [Pull Request] [Update EIP-7928: Move Block Access List outside ExecutionPayload](https://github.com/ethereum/execution-apis/pull/720) - 2025-12-13
 * [Pull Request] []() - 2025-12-20
 * [Pull Request] []() - 2025-12-22
 ## Q3 2025

--- a/members/nerolation.md
+++ b/members/nerolation.md
@@ -31,6 +31,7 @@ Team: [research](https://github.com/nerolation/pglanding-nerolation)
 * [Pull Request] []() - 2026-02-15
 * [Pull Request] []() - 2026-02-16
 * [Pull Request] []() - 2026-02-17
+* [Pull Request] []() - 2026-03-10
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Pull Request] []() - 2026-01-18
 

--- a/members/nethoxa.md
+++ b/members/nethoxa.md
@@ -13,7 +13,7 @@ Team: [ethereum/protocol-security](https://github.com/ethereum/protocol-security
 
 
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [fix builder_index check against validators len](https://github.com/status-im/nimbus-eth2/pull/8042) - 2026-02-26
 ## Q3 2025
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)

--- a/members/nflaig.md
+++ b/members/nflaig.md
@@ -41,6 +41,10 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Pull Request] [chore: pin github actions by commit hash](https://github.com/ChainSafe/lodestar/pull/9017) - 2026-03-10
 * [Commit] [fix:  prune serialized cache by block input keys (#9007)](https://github.com/ChainSafe/lodestar/commit/b847afb846a163fd35c097ddfd40da56325e0e6d) - 2026-03-10
 * [Commit] [chore: pin github actions by commit hash (#9017)](https://github.com/ChainSafe/lodestar/commit/0df187678b8103f2aeb3baf10791281d29a8d914) - 2026-03-10
+* [Review] [Review on: fix:  prune serialized cache by block input keys](https://github.com/ChainSafe/lodestar/pull/9007#pullrequestreview-3921666516) - 2026-03-10
+* [Review] [Review on: fix:  prune serialized cache by block input keys](https://github.com/ChainSafe/lodestar/pull/9007#pullrequestreview-3921814713) - 2026-03-10
+* [Review] [Review on: fix:  prune serialized cache by block input keys](https://github.com/ChainSafe/lodestar/pull/9007#pullrequestreview-3921821026) - 2026-03-10
+* [Review] [Review on: chore(deps): bump the actions group with 13 updates](https://github.com/ChainSafe/lodestar/pull/9018#pullrequestreview-3923099381) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/nflaig.md
+++ b/members/nflaig.md
@@ -12,29 +12,35 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [feat: add getNodeVersionV2 endpoint](https://github.com/ChainSafe/lodestar/pull/8772) - 2026-01-21
 * [Issue] [Consider switching to @vekexasia/bigint-buffer2](https://github.com/ChainSafe/lodestar/issues/8771) - 2026-01-21
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [fix: pass fork info used to compute domain to remote signer](https://github.com/ChainSafe/lodestar/pull/8776) - 2026-01-22
+* [Pull Request] [chore: fix spec refs in 8759](https://github.com/ChainSafe/lodestar/pull/8792) - 2026-01-27
+* [Pull Request] [fix: consistently check block input cache before checking hot db for blocks](https://github.com/ChainSafe/lodestar/pull/8823) - 2026-01-30
+* [Pull Request] [feat: implement epbs block production](https://github.com/ChainSafe/lodestar/pull/8838) - 2026-02-02
+* [Pull Request] [chore: fix fastify deprecation warning about querystringParser](https://github.com/ChainSafe/lodestar/pull/8876) - 2026-02-06
 * [Issue] [Add workflow for nightly generated tests vectors](https://github.com/ChainSafe/lodestar/issues/8871) - 2026-02-06
 * [Issue] [Reuse bytes when deserializing gossip](https://github.com/ChainSafe/lodestar/issues/8870) - 2026-02-06
-* [Pull Request] []() - 2026-02-08
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [feat: update to spec v1.7.0-alpha.2](https://github.com/ChainSafe/lodestar/pull/8881) - 2026-02-08
+* [Pull Request] [chore: avoid unnecessary errors when shutting down the node](https://github.com/ChainSafe/lodestar/pull/8886) - 2026-02-10
 * [Pull Request] []() - 2026-02-12
 * [Issue] [Queuing on api if execution payload envelope is received first](https://github.com/ChainSafe/lodestar/issues/8915) - 2026-02-15
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [feat: implement epbs stateless block production [wip]](https://github.com/ChainSafe/lodestar/pull/8913) - 2026-02-15
+* [Pull Request] [feat: epbs-devnet-0](https://github.com/ChainSafe/lodestar/pull/8939) - 2026-02-20
 * [Issue] [Use milliseconds everywhere](https://github.com/ChainSafe/lodestar/issues/8932) - 2026-02-20
-* [Pull Request] []() - 2026-02-21
+* [Pull Request] [fix: log payload attestations for gloas block bodies](https://github.com/ChainSafe/lodestar/pull/8942) - 2026-02-21
 * [Pull Request] []() - 2026-02-22
 * [Issue] [Update expected withdrawals in gloas payload attributes](https://github.com/ChainSafe/lodestar/issues/8953) - 2026-02-24
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [feat: implement 6-second slots EIP-7782](https://github.com/ChainSafe/lodestar/pull/8966) - 2026-02-27
 * [Issue] [Queue block if parent payload is missing](https://github.com/ChainSafe/lodestar/issues/8981) - 2026-03-04
 * [Issue] [Queue attestations with index=1 for missing payload](https://github.com/ChainSafe/lodestar/issues/8980) - 2026-03-04
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [fix: cache previous epoch payload timeliness committees](https://github.com/ChainSafe/lodestar/pull/8991) - 2026-03-06
+
+[ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
+* [Pull Request] [fix:  prune serialized cache by block input keys](https://github.com/ChainSafe/lodestar/pull/9007) - 2026-03-10
+* [Pull Request] [chore: pin github actions by commit hash](https://github.com/ChainSafe/lodestar/pull/9017) - 2026-03-10
+* [Commit] [fix:  prune serialized cache by block input keys (#9007)](https://github.com/ChainSafe/lodestar/commit/b847afb846a163fd35c097ddfd40da56325e0e6d) - 2026-03-10
+* [Commit] [chore: pin github actions by commit hash (#9017)](https://github.com/ChainSafe/lodestar/commit/0df187678b8103f2aeb3baf10791281d29a8d914) - 2026-03-10
 ## Q4 2025
 
 
@@ -68,15 +74,15 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Pull Request] [fix: avoid emitting stale light client updates](https://github.com/ChainSafe/lodestar/pull/8522) - 2025-10-10
 * [Pull Request] [chore: remove listener of blob sidecars chain event on close](https://github.com/ChainSafe/lodestar/pull/8520) - 2025-10-10
 * [Issue] [Remove usage of `prettyBytes` in errors](https://github.com/ChainSafe/lodestar/issues/8566) - 2025-10-25
-* [Pull Request] []() - 2025-10-29
+* [Pull Request] [feat: activate fulu on ephemery](https://github.com/ChainSafe/lodestar/pull/8587) - 2025-10-29
 * [Issue] [Build provenance and SBOM attestations for images](https://github.com/ChainSafe/lodestar/issues/8610) - 2025-11-05
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-12-17
-* [Pull Request] []() - 2025-12-18
-* [Pull Request] []() - 2025-12-19
-* [Pull Request] []() - 2025-12-22
-* [Pull Request] []() - 2025-12-25
-* [Pull Request] []() - 2025-12-31
+* [Pull Request] [chore: fix test current file launch args](https://github.com/ChainSafe/lodestar/pull/8632) - 2025-11-26
+* [Pull Request] [chore: add lerna exec to fix build watch/ifchanged commands](https://github.com/ChainSafe/lodestar/pull/8704) - 2025-12-17
+* [Pull Request] [chore: restore code required to perform sync through bellatrix](https://github.com/ChainSafe/lodestar/pull/8700) - 2025-12-18
+* [Pull Request] [chore: log aggregation selection errors to debug](https://github.com/ChainSafe/lodestar/pull/8709) - 2025-12-19
+* [Pull Request] [chore: review epbs gossip topic changes](https://github.com/ChainSafe/lodestar/pull/8715) - 2025-12-22
+* [Pull Request] [fix: prevent duplicate aggregates passing validation due to race condition](https://github.com/ChainSafe/lodestar/pull/8716) - 2025-12-25
+* [Pull Request] [refactor: use map to lookup combined beacon committee selection for duty](https://github.com/ChainSafe/lodestar/pull/8710) - 2025-12-31
 ## Q3 2025
 
 

--- a/members/nixorokish.md
+++ b/members/nixorokish.md
@@ -10,19 +10,19 @@ Github: [@nixorokish](https://github.com/nixorokish)
 
 
 [ethereum/pm](https://github.com/ethereum/pm)
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [append-only, don't touch old entries](https://github.com/ethereum/pm/pull/1904) - 2026-01-27
 * [Issue] [All Core Devs - Consensus (ACDC) #174, Feb 5, 2026](https://github.com/ethereum/pm/issues/1907) - 2026-01-28
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [add glam repricing breakout, update breakout instructions w autopilot](https://github.com/ethereum/pm/pull/1908) - 2026-01-29
 
 * [Issue] [All Core Devs - Execution (ACDE) #230, Feb 12, 2026](https://github.com/ethereum/pm/issues/1921) - 2026-02-10
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [add BAL & AWD playlists](https://github.com/ethereum/pm/pull/1926) - 2026-02-12
 * [Issue] [All Core Devs - Execution (ACDE) #231, Feb 26, 2026](https://github.com/ethereum/pm/issues/1931) - 2026-02-17
 * [Issue] [All Core Devs - Consensus (ACDC) #175, Feb 19, 2026](https://github.com/ethereum/pm/issues/1930) - 2026-02-17
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [create config for will corcoran calls to use zoom-bot](https://github.com/ethereum/pm/pull/1937) - 2026-02-18
 * [Issue] [All Core Devs - Consensus (ACDC) #176, Mar 5, 2026](https://github.com/ethereum/pm/issues/1941) - 2026-02-22
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [add EVM static flow control call](https://github.com/ethereum/pm/pull/1947) - 2026-02-23
+* [Pull Request] [add asanso to facilitators](https://github.com/ethereum/pm/pull/1950) - 2026-02-26
 * [Issue] [All Core Devs - Execution (ACDE) #232, March 12, 2026](https://github.com/ethereum/pm/issues/1955) - 2026-03-02
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [Update EIP-7723: Move to Living](https://github.com/ethereum/EIPs/pull/11239) - 2026-02-03
+* [Pull Request] [Update EIP-7607: Move to Final](https://github.com/ethereum/EIPs/pull/11237) - 2026-02-04

--- a/members/parithosh.md
+++ b/members/parithosh.md
@@ -12,15 +12,16 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 
 
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2026-01-10
+* [Pull Request] [The default should have been zkevmgenesis.json instead of the stale zkevm_genesis.json](https://github.com/NethermindEth/gas-benchmarks/pull/93) - 2026-01-10
 
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [All Core Devs - Testing (ACDT) #66, January 19, 2026](https://github.com/ethereum/pm/issues/1878) - 2026-01-15
 * [Issue] [All Core Devs - Testing (ACDT) #68, February 2, 2026](https://github.com/ethereum/pm/issues/1901) - 2026-01-27
 
 * [Issue] [All Core Devs - Testing (ACDT) #72, March 2, 2026](https://github.com/ethereum/pm/issues/1948) - 2026-02-24
+* [Issue] [All Core Devs - Testing (ACDT) #74, March 16, 2026](https://github.com/ethereum/pm/issues/1966) - 2026-03-10
 [ethpandaops/template-devnets](https://github.com/ethpandaops/template-devnets)
-* [Pull Request] []() - 2026-01-28
+* [Pull Request] [Update erigon.yaml](https://github.com/ethpandaops/template-devnets/pull/148) - 2026-01-28
 ## Q4 2025
 
 

--- a/members/parithosh.md
+++ b/members/parithosh.md
@@ -19,6 +19,7 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Issue] [All Core Devs - Testing (ACDT) #68, February 2, 2026](https://github.com/ethereum/pm/issues/1901) - 2026-01-27
 
 * [Issue] [All Core Devs - Testing (ACDT) #72, March 2, 2026](https://github.com/ethereum/pm/issues/1948) - 2026-02-24
+* [Issue] [All Core Devs - Testing (ACDT) #74, March 16, 2026](https://github.com/ethereum/pm/issues/1966) - 2026-03-10
 [ethpandaops/template-devnets](https://github.com/ethpandaops/template-devnets)
 * [Pull Request] []() - 2026-01-28
 ## Q4 2025

--- a/members/pawanjay176.md
+++ b/members/pawanjay176.md
@@ -12,11 +12,11 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Apawa
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2026-01-08
+* [Pull Request] [Get blobs v2 metrics](https://github.com/sigp/lighthouse/pull/8641) - 2026-01-08
 
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-19
+* [Pull Request] [Update buckets for metric](https://github.com/sigp/lighthouse/pull/8651) - 2026-01-13
+* [Pull Request] [Remove state lru cache](https://github.com/sigp/lighthouse/pull/8724) - 2026-01-30
+* [Pull Request] [Process head_chains in descending order of number of peers](https://github.com/sigp/lighthouse/pull/8859) - 2026-02-19
 * [Issue] [Tweak `prepare_payload_lookahead` default value for gloas](https://github.com/sigp/lighthouse/issues/8912) - 2026-02-27
 [ethpandaops/lab](https://github.com/ethpandaops/lab)
 * [Issue] [Use getBlobs info to estimate private blobs](https://github.com/ethpandaops/lab/issues/374) - 2026-01-10
@@ -24,7 +24,7 @@ Team: [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Apawa
 
 
 [sigp/lighthouse](https://github.com/sigp/lighthouse)
-* [Pull Request] []() - 2025-10-23
+* [Pull Request] [Run CI tests only recent forks](https://github.com/sigp/lighthouse/pull/8271) - 2025-10-23
 ## Q3 2025
 
 

--- a/members/petertdavies.md
+++ b/members/petertdavies.md
@@ -22,7 +22,7 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2025-11-04
+* [Pull Request] [fix(fw): Call `get_type_hints()` on class rather than instance](https://github.com/ethereum/execution-specs/pull/1745) - 2025-11-04
 ## Q3 2025
 
 

--- a/members/pinges.md
+++ b/members/pinges.md
@@ -12,7 +12,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Api
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [Enable Gradle parallel execution](https://github.com/besu-eth/besu/pull/9371) - 2025-10-28
 ## Q3 2025
 
 

--- a/members/pk910.md
+++ b/members/pk910.md
@@ -30,6 +30,7 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Pull Request] [improve execution data related query performance](https://github.com/ethpandaops/dora/pull/599) - 2026-03-04
 * [Pull Request] []() - 2026-03-05
 * [Commit] [Merge pull request #602 from ethpandaops/dependabot/npm_and_yarn/ui-package/ui-package-dependencies-98a6424acf](https://github.com/ethpandaops/dora/commit/0457e51a3ac8783c0a5c6c81f774f01f64b17e05) - 2026-03-10
+* [Review] [Review on: Bump the ui-package-dependencies group in /ui-package with 3 updates](https://github.com/ethpandaops/dora/pull/602#pullrequestreview-3926114512) - 2026-03-10
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
 * [Pull Request] [Add Stefan Starflinger from ethPandaOps](https://github.com/protocolguild/documentation/pull/477) - 2026-02-27
 ## Q4 2025

--- a/members/pk910.md
+++ b/members/pk910.md
@@ -12,25 +12,26 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 
 
 [ethpandaops/assertoor](https://github.com/ethpandaops/assertoor)
-* [Pull Request] []() - 2026-02-02
+* [Pull Request] [Assertoor Refactoring / New UI](https://github.com/ethpandaops/assertoor/pull/137) - 2026-02-02
 
-* [Pull Request] []() - 2026-02-19
+* [Pull Request] [Gloas support](https://github.com/ethpandaops/assertoor/pull/142) - 2026-02-19
 [ethpandaops/dora](https://github.com/ethpandaops/dora)
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-02-17
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-22
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [fix sql schema for LOG0 (no topics)](https://github.com/ethpandaops/dora/pull/574) - 2026-02-10
+* [Pull Request] [fix snooper authentication](https://github.com/ethpandaops/dora/pull/575) - 2026-02-11
+* [Pull Request] [fix docker build workflow](https://github.com/ethpandaops/dora/pull/577) - 2026-02-15
+* [Pull Request] [improve tracer compatibility & avoid event duplication](https://github.com/ethpandaops/dora/pull/584) - 2026-02-17
+* [Pull Request] [execution indexer & tx details UI improvements](https://github.com/ethpandaops/dora/pull/585) - 2026-02-18
+* [Pull Request] [context aware page handlers](https://github.com/ethpandaops/dora/pull/586) - 2026-02-22
+* [Pull Request] [execution indexer fix (use valid context for commit phase & reduce memory consumption for trace processing)](https://github.com/ethpandaops/dora/pull/590) - 2026-02-23
 * [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [Heze support (FOCIL)](https://github.com/ethpandaops/dora/pull/592) - 2026-02-26
 
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-04
+* [Pull Request] [Pre-capella copatiblity & eip7702 authorizations in tx details](https://github.com/ethpandaops/dora/pull/596) - 2026-03-03
+* [Pull Request] [improve execution data related query performance](https://github.com/ethpandaops/dora/pull/599) - 2026-03-04
 * [Pull Request] []() - 2026-03-05
+* [Commit] [Merge pull request #602 from ethpandaops/dependabot/npm_and_yarn/ui-package/ui-package-dependencies-98a6424acf](https://github.com/ethpandaops/dora/commit/0457e51a3ac8783c0a5c6c81f774f01f64b17e05) - 2026-03-10
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [Add Stefan Starflinger from ethPandaOps](https://github.com/protocolguild/documentation/pull/477) - 2026-02-27
 ## Q4 2025
 
 
@@ -55,17 +56,17 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Commit] [add spec mismatch visualization](https://github.com/ethpandaops/dora/commit/71269dc74be555a76a55801ea33082c35bd47ce3) - 2025-10-13
 * [Commit] [Merge pull request #498 from ethpandaops/pk910/fix-snooper-urls-in-make-devnet](https://github.com/ethpandaops/dora/commit/f6a19dfc1a58fc14fdb5af7fdbe88b28c3554559) - 2025-10-13
 * [Issue] [panic on holesky instance](https://github.com/ethpandaops/dora/issues/518) - 2025-11-18
-* [Pull Request] []() - 2025-11-24
-* [Pull Request] []() - 2025-12-10
+* [Pull Request] [use majority spec values](https://github.com/ethpandaops/dora/pull/521) - 2025-11-24
+* [Pull Request] [publish releases](https://github.com/ethpandaops/dora/pull/534) - 2025-12-10
 [ethpandaops/assertoor](https://github.com/ethpandaops/assertoor)
 * [Commit] [Bump the dependencies group across 1 directory with 6 updates](https://github.com/ethpandaops/assertoor/commit/53487200aa7bfcbd030c50cc539aad8689773278) - 2025-10-01
 * [Commit] [Bump the actions group across 1 directory with 5 updates](https://github.com/ethpandaops/assertoor/commit/a04bf8c8d8aa653592138e0a1a38a1fb7bc51e01) - 2025-10-01
 * [Commit] [add fulu support](https://github.com/ethpandaops/assertoor/commit/3fe13cb4da01997e1b497a80992da9ec8c670f7a) - 2025-10-01
 * [Commit] [remove go-eth2-client replacement](https://github.com/ethpandaops/assertoor/commit/ecc0d6c96a33f599f344cb8a5b5d6f9d9889c6e9) - 2025-10-01
 
-* [Pull Request] []() - 2025-12-27
+* [Pull Request] [add support for fusaka blob format in `generate_blob_transactions` task](https://github.com/ethpandaops/assertoor/pull/133) - 2025-12-27
 [prysmaticlabs/hashtree](https://github.com/prysmaticlabs/hashtree)
-* [Pull Request] []() - 2025-10-19
+* [Pull Request] [use statically build libraries instead of syso files](https://github.com/OffchainLabs/hashtree/pull/53) - 2025-10-19
 ## Q3 2025
 
 [ethpandaops/dora](https://github.com/ethpandaops/dora)

--- a/members/poojaranjan.md
+++ b/members/poojaranjan.md
@@ -26,16 +26,16 @@ Team: [ethereum/pm](https://github.com/ethereum/pm/pulls?q=is%3Apr+is%3Aclosed+p
 * [Issue] [EIP Editing Office Hour (EIP + ERC ) Meeting #91, March 03, 2026](https://github.com/ethereum/pm/issues/1957) - 2026-03-03
 * [Issue] [EIP Editing Office Hour (EIP + ERC ) Meeting #92, March 11, 2026](https://github.com/ethereum/pm/issues/1961) - 2026-03-05
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-03
-* [Pull Request] []() - 2026-01-21
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-23
-* [Pull Request] []() - 2026-01-24
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [Update EIP-7723: Update eip-7723.md](https://github.com/ethereum/EIPs/pull/11006) - 2026-01-03
+* [Pull Request] [Update EIP-7910: Move to Final](https://github.com/ethereum/EIPs/pull/11135) - 2026-01-21
+* [Pull Request] [Update EIP-7892: Move to Final](https://github.com/ethereum/EIPs/pull/11152) - 2026-01-22
+* [Pull Request] [Add EIP: Upgrade Nomenclature](https://github.com/ethereum/EIPs/pull/11161) - 2026-01-23
+* [Pull Request] [Add EIP: Hardfork Meta - BPO2](https://github.com/ethereum/EIPs/pull/11165) - 2026-01-24
+* [Pull Request] [Website: Update eip.html](https://github.com/ethereum/EIPs/pull/11201) - 2026-01-29
+* [Pull Request] [Website: Remove `Online Serial` from "Citation".](https://github.com/ethereum/EIPs/pull/11268) - 2026-02-05
+* [Pull Request] [Add contribution guidelines for EIP repository](https://github.com/ethereum/EIPs/pull/11124) - 2026-02-10
+* [Pull Request] [Add EIP: Hardfork Meta - BPO3](https://github.com/ethereum/EIPs/pull/11182) - 2026-02-24
+* [Pull Request] [Update EIP-8135: Move to Review](https://github.com/ethereum/EIPs/pull/11370) - 2026-03-03
 ## Q4 2025
 
 

--- a/members/potuz.md
+++ b/members/potuz.md
@@ -12,30 +12,36 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Apotuz) , [
 
 
 [offchainlabs/hashtree](https://github.com/offchainlabs/hashtree)
-* [Pull Request] []() - 2026-01-07
+* [Pull Request] [refactor: unroll macros in x86-64 assembly for Clang compatibility](https://github.com/OffchainLabs/hashtree/pull/57) - 2026-01-07
 * [Pull Request] []() - 2026-01-08
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-11
-* [Pull Request] []() - 2026-01-12
+* [Pull Request] [Add feature flag to verify signatures before proposing](https://github.com/OffchainLabs/prysm/pull/15920) - 2026-01-09
+* [Pull Request] [Update Spectests to v1.7.0.alpha-1](https://github.com/OffchainLabs/prysm/pull/16246) - 2026-01-11
+* [Pull Request] [Use dependent root when validating data column](https://github.com/OffchainLabs/prysm/pull/16250) - 2026-01-12
 
 * [Issue] [should be able to get non-canonical blocks](https://github.com/OffchainLabs/prysm/issues/16342) - 2026-02-09
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-01
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Only call FCU pre-Gloas](https://github.com/OffchainLabs/prysm/pull/16373) - 2026-02-19
+* [Pull Request] [Gloas/forkchoice ptc](https://github.com/OffchainLabs/prysm/pull/16392) - 2026-02-23
+* [Pull Request] [Make Dora Happy](https://github.com/OffchainLabs/prysm/pull/16441) - 2026-02-27
+* [Pull Request] [Fixed topic name for Gloas](https://github.com/OffchainLabs/prysm/pull/16443) - 2026-03-01
+* [Pull Request] [Do not reject on blocks unless they are provably bad](https://github.com/OffchainLabs/prysm/pull/16471) - 2026-03-04
+* [Pull Request] [Fix replay blocks](https://github.com/OffchainLabs/prysm/pull/16482) - 2026-03-05
+* [Pull Request] [Dont fail seting fc](https://github.com/OffchainLabs/prysm/pull/16478) - 2026-03-06
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-01-26
+* [Pull Request] [Remove KZG commitments from payload envelope](https://github.com/ethereum/consensus-specs/pull/4864) - 2026-01-26
 * [Issue] [gloas fork should add builder deposits for previous epochs](https://github.com/ethereum/consensus-specs/issues/4867) - 2026-01-27
 * [Issue] [process_builder_pending_payments can go anywhere](https://github.com/ethereum/consensus-specs/issues/4866) - 2026-01-27
 * [Issue] [should proposer boost be counted in `is_parent_strong`?](https://github.com/ethereum/consensus-specs/issues/4899) - 2026-02-03
-* [Pull Request] []() - 2026-02-03
+* [Pull Request] [Remove pending status from tiebreaker](https://github.com/ethereum/consensus-specs/pull/4898) - 2026-02-03
 * [Issue] [Allow attesters/proposers to override value of `is_payload_data_available`](https://github.com/ethereum/consensus-specs/issues/4907) - 2026-02-09
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [Only allow attestations for known payload statuses](https://github.com/ethereum/consensus-specs/pull/4918) - 2026-02-13
+
+[OffchainLabs/prysm](https://github.com/OffchainLabs/prysm)
+* [Pull Request] [Use execution block hash as state access key post-Gloas](https://github.com/OffchainLabs/prysm/pull/16459) - 2026-03-10
+* [Pull Request] [Handle missing Payloads](https://github.com/OffchainLabs/prysm/pull/16460) - 2026-03-10
+* [Commit] [Use execution block hash as state access key post-Gloas (#16459)](https://github.com/OffchainLabs/prysm/commit/932e5eb7d8b0ed74aec37df6fc9a55a82c75f0ec) - 2026-03-10
+* [Commit] [Handle missing Payloads (#16460)](https://github.com/OffchainLabs/prysm/commit/e35f6c351a52c7c12a163bf006c5a5c0efe221fd) - 2026-03-10
 ## Q4 2025
 
 
@@ -45,22 +51,22 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Apotuz) , [
 * [Commit] [Add tests](https://github.com/OffchainLabs/prysm/commit/7b99d305cf9e304131693613547f2f8eec832859) - 2025-10-13
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2025-11-06
+* [Pull Request] [Dependent root instead of target](https://github.com/OffchainLabs/prysm/pull/15996) - 2025-11-06
 
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-09
+* [Pull Request] [Fix linter](https://github.com/OffchainLabs/prysm/pull/16058) - 2025-11-26
+* [Pull Request] [Track the dependent root of the latest finalized checkpoint](https://github.com/OffchainLabs/prysm/pull/16103) - 2025-12-05
+* [Pull Request] [Use head to validate atts for previous epoch](https://github.com/OffchainLabs/prysm/pull/16109) - 2025-12-08
+* [Pull Request] [Fix TOCTOU race validating attestations](https://github.com/OffchainLabs/prysm/pull/16105) - 2025-12-09
 * [Issue] [SIGSEGV in init sync](https://github.com/OffchainLabs/prysm/issues/16125) - 2025-12-10
-* [Pull Request] []() - 2025-12-13
-* [Pull Request] []() - 2025-12-15
-* [Pull Request] []() - 2025-12-19
-* [Pull Request] []() - 2025-12-26
-* [Pull Request] []() - 2025-12-30
-* [Pull Request] []() - 2025-12-31
+* [Pull Request] [Do not error when indices have been computed](https://github.com/OffchainLabs/prysm/pull/16142) - 2025-12-13
+* [Pull Request] [Remove proposer cache](https://github.com/OffchainLabs/prysm/pull/16147) - 2025-12-15
+* [Pull Request] [Do not process slots and copy state for payload attributes post Fulu](https://github.com/OffchainLabs/prysm/pull/16168) - 2025-12-19
+* [Pull Request] [Do not send FCU on block batches](https://github.com/OffchainLabs/prysm/pull/16199) - 2025-12-26
+* [Pull Request] [Call FCU in the background](https://github.com/OffchainLabs/prysm/pull/16149) - 2025-12-30
+* [Pull Request] [Hdiff start database](https://github.com/OffchainLabs/prysm/pull/16203) - 2025-12-31
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-08
+* [Pull Request] [Fix randao mix processing in Gloas](https://github.com/ethereum/consensus-specs/pull/4728) - 2025-11-07
+* [Pull Request] [Add off-protocol value to the bid](https://github.com/ethereum/consensus-specs/pull/4733) - 2025-11-08
 ## Q3 2025
 
 

--- a/members/povi.md
+++ b/members/povi.md
@@ -12,7 +12,7 @@ Team: Grandine
 
 
 [grandinetech/grandine](https://github.com/grandinetech/grandine)
-* [Pull Request] []() - 2026-02-19
+* [Pull Request] [Delay after finalization archive tasks to be performed later in slot](https://github.com/grandinetech/grandine/pull/605) - 2026-02-19
 ## Q4 2025
 
 
@@ -23,14 +23,14 @@ Team: Grandine
 * [Pull Request] [Debug P2p message handling performance](https://github.com/grandinetech/grandine/pull/409) - 2025-10-08
 * [Pull Request] [Ensure peer connected only after other sync checks to avoid unnecessary peer collection locking](https://github.com/grandinetech/grandine/pull/412) - 2025-10-09
 
-* [Pull Request] []() - 2025-10-17
-* [Pull Request] []() - 2025-10-20
-* [Pull Request] []() - 2025-11-04
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-11-11
-* [Pull Request] []() - 2025-12-05
+* [Pull Request] [Don't send whole head state to P2p on head change](https://github.com/grandinetech/grandine/pull/431) - 2025-10-17
+* [Pull Request] [Run metrics service system stats refresh in tokio blocking task](https://github.com/grandinetech/grandine/pull/438) - 2025-10-20
+* [Pull Request] [Increase `engine_getBlobsV*` request timeout to 2s](https://github.com/grandinetech/grandine/pull/465) - 2025-11-04
+* [Pull Request] [Add cooldown to `too many empty slots` message in liveness tracking](https://github.com/grandinetech/grandine/pull/473) - 2025-11-10
+* [Pull Request] [Fix `Mutator` performance issues related to data column reconstruction](https://github.com/grandinetech/grandine/pull/474) - 2025-11-11
+* [Pull Request] [Add `/features` endpoints](https://github.com/grandinetech/grandine/pull/520) - 2025-12-05
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-10-14
+* [Pull Request] [eip7732: swap `beacon_block_root` and `slot` in places in `DataColumnSidecar`](https://github.com/ethereum/consensus-specs/pull/4656) - 2025-10-14
 ## Q3 2025
 
 

--- a/members/prestonvanloon.md
+++ b/members/prestonvanloon.md
@@ -12,15 +12,15 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Aprestonvan
 
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-07
+* [Pull Request] [Fix issue : Prevent makeslice panic from invalid Count values](https://github.com/OffchainLabs/prysm/pull/16227) - 2026-01-07
 
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [CI: Add gazelle update-repos check](https://github.com/OffchainLabs/prysm/pull/16257) - 2026-01-15
 * [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [golangci-lint: Remove test exclusion from formatting](https://github.com/OffchainLabs/prysm/pull/16318) - 2026-02-02
+* [Pull Request] [db: Copy byte slices that live outside of the view transaction](https://github.com/OffchainLabs/prysm/pull/16332) - 2026-02-07
+* [Pull Request] [api: reduce gzip compression level](https://github.com/OffchainLabs/prysm/pull/16399) - 2026-02-24
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-13
+* [Pull Request] [Add Satyajit Das to Prysm](https://github.com/protocolguild/documentation/pull/470) - 2026-01-13
 * [Pull Request] []() - 2026-01-20
 ## Q4 2025
 
@@ -32,8 +32,8 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Aprestonvan
 * [Pull Request] [Clear disconnected peers from connected_libp2p_peers](https://github.com/OffchainLabs/prysm/pull/15807) - 2025-10-03
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2025-11-10
-* [Pull Request] []() - 2025-12-11
+* [Pull Request] [Update CHANGELOG.md for v7.0.0 release](https://github.com/OffchainLabs/prysm/pull/16004) - 2025-11-10
+* [Pull Request] [Update CHANGELOG.md for v7.1.0 release](https://github.com/OffchainLabs/prysm/pull/16127) - 2025-12-11
 ## Q3 2025
 
 

--- a/members/pvecchiarelli.md
+++ b/members/pvecchiarelli.md
@@ -12,6 +12,6 @@ Team: [protocolguild/documentation](https://github.com/protocolguild/documentati
 
 
 [protocolguild/protocol-guild-site](https://github.com/protocolguild/protocol-guild-site)
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Add Shutter PGP Blog Post + Image](https://github.com/protocolguild/protocol-guild-site/pull/46) - 2026-02-03
+* [Pull Request] [Update 20260224-Q1-quarterly-audit.md](https://github.com/protocolguild/protocol-guild-site/pull/48) - 2026-02-25
+* [Pull Request] [feat: native docs section with sidebar navigation](https://github.com/protocolguild/protocol-guild-site/pull/50) - 2026-03-09

--- a/members/rakita.md
+++ b/members/rakita.md
@@ -15,37 +15,40 @@ Team: [Revm](https://github.com/bluealloy/revm/commits/main/?author=rakita)
 * [Issue] [Add pritty_print for CacheDB](https://github.com/bluealloy/revm/issues/3283) - 2026-01-06
 * [Issue] [Make a bytecode test utility that would make bytecode that insert input directly to memory](https://github.com/bluealloy/revm/issues/3277) - 2026-01-06
 * [Issue] [Add Inspector testing bootstrap for evm variants that extend revm](https://github.com/bluealloy/revm/issues/3275) - 2026-01-06
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [chore: apply improvements from ai-bot labeled PRs](https://github.com/bluealloy/revm/pull/3297) - 2026-01-09
+* [Pull Request] [chore: bump cargo.toml](https://github.com/bluealloy/revm/pull/3311) - 2026-01-14
 * [Issue] [GasParams helper for access list](https://github.com/bluealloy/revm/issues/3343) - 2026-01-22
 * [Issue] [Helper for GasParams cold_storage_cost()](https://github.com/bluealloy/revm/issues/3342) - 2026-01-22
 * [Issue] [Configure gas_params Auth refund amount](https://github.com/bluealloy/revm/issues/3341) - 2026-01-22
-* [Pull Request] []() - 2026-01-26
+* [Pull Request] [fix: set transition_id to account](https://github.com/bluealloy/revm/pull/3353) - 2026-01-26
 
-* [Pull Request] []() - 2026-01-28
+* [Pull Request] [Deprecate `nonce_bump_journal_entry` and `caller_accounting_journal_entry` functions](https://github.com/bluealloy/revm/pull/3367) - 2026-01-28
 * [Issue] [Deprecate nonce_bump_journal_entry(), caller_accounting_journal_entry](https://github.com/bluealloy/revm/issues/3365) - 2026-01-28
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [chore(scripts): update devnet test fixtures to bal@v5.1.0](https://github.com/bluealloy/revm/pull/3392) - 2026-02-02
+* [Pull Request] [feat(statetest-types): add BPO2ToAmsterdamAtTime15k fork spec](https://github.com/bluealloy/revm/pull/3397) - 2026-02-03
+* [Pull Request] [feat: add EIP-8037 / TIP-1016 state gas support](https://github.com/bluealloy/revm/pull/3406) - 2026-02-06
+* [Pull Request] [refactor!: add ResultGas struct to ExecutionResult](https://github.com/bluealloy/revm/pull/3413) - 2026-02-09
 * [Issue] [Add aws-lc-rs as alternative to secp256r1 precompile](https://github.com/bluealloy/revm/issues/3417) - 2026-02-10
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [feat(revme): validate block gas used in blockchain tests](https://github.com/bluealloy/revm/pull/3416) - 2026-02-10
+* [Pull Request] [refactor: implement reservoir model in Gas struct](https://github.com/bluealloy/revm/pull/3418) - 2026-02-11
+* [Pull Request] [refactor!: add logs to Revert and Halt variants of ExecutionResult](https://github.com/bluealloy/revm/pull/3424) - 2026-02-12
 * [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [bench: add subcall benchmarks (1000-call variants)](https://github.com/bluealloy/revm/pull/3427) - 2026-02-16
+* [Pull Request] [refactor(handler): remove Default for EthPrecompiles and EthInstructions](https://github.com/bluealloy/revm/pull/3434) - 2026-02-23
+* [Pull Request] [refactor(gas): simplify log2floor implementation](https://github.com/bluealloy/revm/pull/3440) - 2026-02-24
+* [Pull Request] [devnet2-revm: sync revm main into staging](https://github.com/bluealloy/revm/pull/3445) - 2026-02-25
+* [Pull Request] [chore: bump c-kzg from 2.1.4 to 2.1.6](https://github.com/bluealloy/revm/pull/3448) - 2026-02-26
+* [Pull Request] [feat(precompile): add herumi/mcl as alternative backend for bn254](https://github.com/bluealloy/revm/pull/3452) - 2026-02-27
+* [Pull Request] [docs: add v104 migration guide](https://github.com/bluealloy/revm/pull/3468) - 2026-03-02
+* [Pull Request] [fix: expose JournalLoadError from load_account_mut_skip_cold_load](https://github.com/bluealloy/revm/pull/3477) - 2026-03-04
+* [Pull Request] [chore: bump aws-lc-rs from 1.16.0 to 1.16.1](https://github.com/bluealloy/revm/pull/3481) - 2026-03-05
 * [Issue] [tip1016 pending spec changes](https://github.com/bluealloy/revm/issues/3480) - 2026-03-05
 * [Pull Request] []() - 2026-03-06
+* [Pull Request] [feat(revme): list all failed tests at the end with --keep-going](https://github.com/bluealloy/revm/pull/3491) - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [Update EIP-7708: Clarify transaction transfer to different account](https://github.com/ethereum/EIPs/pull/11188) - 2026-01-27
+* [Pull Request] [Add EIP: Composable Transaction](https://github.com/ethereum/EIPs/pull/11355) - 2026-03-10
+* [Commit] [Add EIP: Composable Transaction](https://github.com/ethereum/EIPs/commit/248b653f875c244ebdfdaed94d8ef54e54574b00) - 2026-03-10
 ## Q4 2025
 
 
@@ -87,12 +90,12 @@ Team: [Revm](https://github.com/bluealloy/revm/commits/main/?author=rakita)
 * [Commit] [perf: resize short addresses bitvec instead of reallocating (#3083)](https://github.com/bluealloy/revm/commit/10ff66da1576a3532db657d7b953abcd59ec44a3) - 2025-10-13
 * [Commit] [refactor(handler): extract duplicate gas price validation (#3045)](https://github.com/bluealloy/revm/commit/0ce9fc5794e39def74d788316a7cfafbe7cdbaef) - 2025-10-13
 * [Commit] [chore: make CallInput::bytes accept immutable ContextTr (#3082)](https://github.com/bluealloy/revm/commit/082a5dd4d90f6d1233e1b6281ae24259a5a40895) - 2025-10-13
-* [Pull Request] []() - 2025-10-29
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [feat: Gas params](https://github.com/bluealloy/revm/pull/3132) - 2025-10-29
+* [Pull Request] [feat: Add set nonce journal entry and fn](https://github.com/bluealloy/revm/pull/3163) - 2025-11-12
+* [Pull Request] [feat: JournaledAccount sload/sstore](https://github.com/bluealloy/revm/pull/3201) - 2025-12-02
 * [Issue] [Configurable tx validation](https://github.com/bluealloy/revm/issues/3215) - 2025-12-08
 * [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-16
+* [Pull Request] [feat: move GasParams to Cfg](https://github.com/bluealloy/revm/pull/3229) - 2025-12-16
 ## Q3 2025
 
 

--- a/members/rakita.md
+++ b/members/rakita.md
@@ -44,6 +44,7 @@ Team: [Revm](https://github.com/bluealloy/revm/commits/main/?author=rakita)
 * [Pull Request] []() - 2026-03-05
 * [Issue] [tip1016 pending spec changes](https://github.com/bluealloy/revm/issues/3480) - 2026-03-05
 * [Pull Request] []() - 2026-03-06
+* [Pull Request] []() - 2026-03-10
 [ethereum/eips](https://github.com/ethereum/eips)
 * [Pull Request] []() - 2026-01-27
 ## Q4 2025

--- a/members/ralexstokes.md
+++ b/members/ralexstokes.md
@@ -12,17 +12,17 @@ Team: Applied Research Group (ARG)
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [Update EIP-7773: update EIP status for glamsterdam](https://github.com/ethereum/EIPs/pull/10958) - 2026-01-05
+* [Pull Request] [Update EIP-8081: move FOCIL to SFI](https://github.com/ethereum/EIPs/pull/11341) - 2026-02-20
 ## Q4 2025
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-10-21
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-03
-* [Pull Request] []() - 2025-12-20
+* [Pull Request] [Update EIP-7773: clean up duplication from #10559](https://github.com/ethereum/EIPs/pull/10580) - 2025-10-21
+* [Pull Request] [Update EIP-7773: Move EIP-8068 to DFI for Glamsterdam](https://github.com/ethereum/EIPs/pull/10841) - 2025-11-26
+* [Pull Request] [Update EIP-7773: update glamsterdam scope](https://github.com/ethereum/EIPs/pull/10861) - 2025-12-02
+* [Pull Request] [Add EIP: Hardfork Meta - Heka/Bogotá](https://github.com/ethereum/EIPs/pull/10772) - 2025-12-03
+* [Pull Request] [Update EIP-8081: update portmanteau for Hegotá](https://github.com/ethereum/EIPs/pull/10957) - 2025-12-20
 ## Q2 2025
 
 

--- a/members/raxhvl.md
+++ b/members/raxhvl.md
@@ -14,14 +14,14 @@ Team: EF Protocol Prototyping [raxhvl/pglanding-raxhvl](https://github.com/raxhv
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Add support for fork-level EVM simulation](https://github.com/ethereum/execution-specs/issues/1990) - 2026-01-08
 
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [feat(tests): EIP-7928 tests for EIP 2935](https://github.com/ethereum/execution-specs/pull/2113) - 2026-02-18
 * [Issue] [Suggestion: For tests, let the default tx gas limit be the maximum allowed value](https://github.com/ethereum/execution-specs/issues/2248) - 2026-02-20
 * [Issue] [Implement EIP-7954](https://github.com/ethereum/execution-specs/issues/2275) - 2026-02-23
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [Update EIP-7708: Add ETH burn logs and improve spec consistency](https://github.com/ethereum/EIPs/pull/11311) - 2026-02-13
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-02-15
+* [Pull Request] [core, core/vm:  Rename selfdestruct log to burn](https://github.com/ethereum/go-ethereum/pull/33851) - 2026-02-15
 * [Issue] [chore(Amsterdam): Break up tiered gas pricing](https://github.com/ethereum/go-ethereum/issues/33939) - 2026-03-03
 ## Q4 2025
 
@@ -37,13 +37,13 @@ Team: EF Protocol Prototyping [raxhvl/pglanding-raxhvl](https://github.com/raxhv
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [chore: Rename `tx_index` to `bal_index` for `BlockAccessList`](https://github.com/ethereum/execution-specs/issues/1617) - 2025-10-16
 * [Issue] [Enforce strict field validation on critical pydantic model](https://github.com/ethereum/execution-specs/issues/1615) - 2025-10-16
-* [Pull Request] []() - 2025-12-07
+* [Pull Request] [feat(tests): EIP-7928 OOG edge cases for EIP-7702 delegations](https://github.com/ethereum/execution-specs/pull/1856) - 2025-12-07
 * [Issue] [EIP-7928 BAL does not record EIP-4788 timestamp read operation for invalid queries](https://github.com/ethereum/execution-specs/issues/1889) - 2025-12-10
 * [Issue] [EIP-7928 BAL does NOT include system contract addresss](https://github.com/ethereum/execution-specs/issues/1886) - 2025-12-10
-* [Pull Request] []() - 2025-12-14
+* [Pull Request] [✨ feat(tests): EIP-7928 tests targeting EIP-7002](https://github.com/ethereum/execution-specs/pull/1918) - 2025-12-14
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [Update EIP-7002: Amount endianness](https://github.com/ethereum/EIPs/pull/10945) - 2025-12-17
 ## Q3 2025
 
 [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests)

--- a/members/rjected.md
+++ b/members/rjected.md
@@ -12,18 +12,25 @@ Team: Reth
 
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
-* [Pull Request] []() - 2026-01-17
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-03
+* [Pull Request] [perf: make Chain use DeferredTrieData](https://github.com/paradigmxyz/reth/pull/21137) - 2026-01-17
+* [Pull Request] [fix(cli): delete all static files when PruneModes::Full is configured](https://github.com/paradigmxyz/reth/pull/21647) - 2026-01-30
+* [Pull Request] [chore(cli): expose static file metrics in cli](https://github.com/paradigmxyz/reth/pull/21770) - 2026-02-03
 * [Issue] [`reth prune` does not delete AccountHistory/StoragesHistory/TransactionHashNumbers from rocksdb](https://github.com/paradigmxyz/reth/issues/21713) - 2026-02-02
 * [Issue] [Support Ctrl-C in `reth prune`](https://github.com/paradigmxyz/reth/issues/21756) - 2026-02-03
-* [Pull Request] []() - 2026-02-07
+* [Pull Request] [chore(persistence): delete ambiguous TODO](https://github.com/paradigmxyz/reth/pull/21923) - 2026-02-07
 * [Issue] [`--minimal` with senders in static files cannot handle completely missing senders](https://github.com/paradigmxyz/reth/issues/21914) - 2026-02-06
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [fix(consistent): actually use range in storage range query](https://github.com/paradigmxyz/reth/pull/22043) - 2026-02-10
+* [Pull Request] [perf: touch entire mdbx in background on startup](https://github.com/paradigmxyz/reth/pull/22156) - 2026-02-13
+* [Pull Request] [fix: detect and remove stale CLI doc pages](https://github.com/paradigmxyz/reth/pull/22433) - 2026-02-20
+* [Pull Request] [fix(stages): bound storage hashing stages memory](https://github.com/paradigmxyz/reth/pull/22721) - 2026-03-04
+* [Pull Request] [fix(cli): fix ctrl-C in reth downloads](https://github.com/paradigmxyz/reth/pull/22851) - 2026-03-06
+* [Pull Request] [chore(cli): add --with-senders and --with-rocksdb for niche presets](https://github.com/paradigmxyz/reth/pull/22933) - 2026-03-10
+* [Pull Request] [fix(ci): remove hashing stages from stage-run-test for storage v2](https://github.com/paradigmxyz/reth/pull/22929) - 2026-03-10
+* [Pull Request] [fix(ci): remove issue_comment: edited from bench trigger](https://github.com/paradigmxyz/reth/pull/22925) - 2026-03-10
+* [Pull Request] [feat(cli): make storage v2 default for new nodes](https://github.com/paradigmxyz/reth/pull/22890) - 2026-03-10
+* [Commit] [fix(ci): remove hashing stages from stage-run-test for storage v2 (#22929)](https://github.com/paradigmxyz/reth/commit/d6b1d0677212b13e3c8f00fe0c65766501f6217b) - 2026-03-10
+* [Commit] [fix(ci): remove issue_comment: edited from bench trigger (#22925)](https://github.com/paradigmxyz/reth/commit/406b95b55571f6ef48ee7c7bf1b9c34bb220ec1a) - 2026-03-10
+* [Commit] [feat(cli): make storage v2 default for new nodes (#22890)](https://github.com/paradigmxyz/reth/commit/5ea37acbdb0bf8971a0424afd4d62c140186af4f) - 2026-03-10
 ## Q4 2025
 
 
@@ -42,10 +49,10 @@ Team: Reth
 * [Commit] [fix: use proper value for account changeset static files](https://github.com/paradigmxyz/reth/commit/0dcc313eb57b15644fa7cb81269a2a849e565671) - 2025-10-08
 * [Commit] [chore: add stub for account_before_block](https://github.com/paradigmxyz/reth/commit/4079bfe28d600d39a8dc58679ee4472fa30c9567) - 2025-10-08
 * [Commit] [docs: yellowpaper sections in consensus implementation (#18881)](https://github.com/paradigmxyz/reth/commit/83cec3793bb2300c76f1aeb88aac1e1a96309f34) - 2025-10-08
-* [Pull Request] []() - 2025-10-18
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-11-14
+* [Pull Request] [feat: add capacity metrics for tries](https://github.com/paradigmxyz/reth/pull/19117) - 2025-10-18
+* [Pull Request] [chore(trie): add number of target slots to storage proof span](https://github.com/paradigmxyz/reth/pull/19590) - 2025-11-07
+* [Pull Request] [chore(engine): add basic tx result information to execution spans](https://github.com/paradigmxyz/reth/pull/19698) - 2025-11-12
+* [Pull Request] [fix(cli): always commit the unwind for stage run headers](https://github.com/paradigmxyz/reth/pull/19768) - 2025-11-14
 * [Issue] [Add method to check invariants on RocksDB tables](https://github.com/paradigmxyz/reth/issues/20153) - 2025-12-05
 * [Issue] [Add RocksDB Provider to DatabaseProvider](https://github.com/paradigmxyz/reth/issues/20152) - 2025-12-05
 * [Issue] [Add StorageSettings for StoragesHistory in RocksDB](https://github.com/paradigmxyz/reth/issues/20151) - 2025-12-05

--- a/members/rjected.md
+++ b/members/rjected.md
@@ -24,6 +24,7 @@ Team: Reth
 * [Pull Request] []() - 2026-02-20
 * [Pull Request] []() - 2026-03-04
 * [Pull Request] []() - 2026-03-06
+* [Pull Request] []() - 2026-03-10
 ## Q4 2025
 
 

--- a/members/rjected.md
+++ b/members/rjected.md
@@ -31,6 +31,9 @@ Team: Reth
 * [Commit] [fix(ci): remove hashing stages from stage-run-test for storage v2 (#22929)](https://github.com/paradigmxyz/reth/commit/d6b1d0677212b13e3c8f00fe0c65766501f6217b) - 2026-03-10
 * [Commit] [fix(ci): remove issue_comment: edited from bench trigger (#22925)](https://github.com/paradigmxyz/reth/commit/406b95b55571f6ef48ee7c7bf1b9c34bb220ec1a) - 2026-03-10
 * [Commit] [feat(cli): make storage v2 default for new nodes (#22890)](https://github.com/paradigmxyz/reth/commit/5ea37acbdb0bf8971a0424afd4d62c140186af4f) - 2026-03-10
+* [Review] [Review on: feat(download): use snapshots.reth.rs API with --list](https://github.com/paradigmxyz/reth/pull/22859#pullrequestreview-3924651371) - 2026-03-10
+* [Review] [Review on: feat(download): use snapshots.reth.rs API with --list](https://github.com/paradigmxyz/reth/pull/22859#pullrequestreview-3925470256) - 2026-03-10
+* [Review] [Review on: feat: add verisions to the reth download metadata](https://github.com/paradigmxyz/reth/pull/22921#pullrequestreview-3923344138) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/rjl493456442.md
+++ b/members/rjl493456442.md
@@ -12,11 +12,13 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [core/state: add cache statistics of contract code reader](https://github.com/ethereum/go-ethereum/pull/33532) - 2026-01-06
+* [Pull Request] [core: extend the code reader statistics](https://github.com/ethereum/go-ethereum/pull/33659) - 2026-01-22
+* [Pull Request] [triedb/pathdb: improve trienode reader for searching](https://github.com/ethereum/go-ethereum/pull/33681) - 2026-01-27
+* [Pull Request] [core/rawdb: revert "check pruning tail in HasBody and HasReceipts"](https://github.com/ethereum/go-ethereum/pull/33865) - 2026-02-18
 * [Pull Request] []() - 2026-02-19
+* [Pull Request] [core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816) - 2026-03-10
+* [Commit] [core, miner, tests: introduce codedb and simplify cachingDB (#33816)](https://github.com/ethereum/go-ethereum/commit/91cec92bf364525e03b9c449de26ab0b15cfe9b1) - 2026-03-10
 ## Q4 2025
 
 
@@ -29,25 +31,25 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 * [Commit] [p2p: rm unused var seedMinTableTime (#32876)](https://github.com/ethereum/go-ethereum/commit/85e9977faecd23909b0373ae4c8268e8bf62b6a3) - 2025-10-13
 * [Commit] [core/types: optimize MergeBloom by using bitutil (#32882)](https://github.com/ethereum/go-ethereum/commit/2010781c2998557ccf9883155b6ff4e73d1d64a0) - 2025-10-13
 * [Commit] [node: fix error condition in gzipResponseWriter.init() (#32896)](https://github.com/ethereum/go-ethereum/commit/a3aae29845736cbf40c2bedbdee1c3396dd2f88c) - 2025-10-13
-* [Pull Request] []() - 2025-10-16
+* [Pull Request] [core: prioritize the heavy transaction for prefetching](https://github.com/ethereum/go-ethereum/pull/32923) - 2025-10-16
 * [Issue] [Hash the account trie along with storage tries in parallel](https://github.com/ethereum/go-ethereum/issues/32922) - 2025-10-16
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [core/state: parallelize the account trie hash along with storages](https://github.com/ethereum/go-ethereum/pull/33037) - 2025-10-28
 
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [core/state: introduce state iterator interface](https://github.com/ethereum/go-ethereum/pull/33102) - 2025-11-05
 * [Issue] [Remove table printer from the dependency](https://github.com/ethereum/go-ethereum/issues/33212) - 2025-11-17
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-04
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-16
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [triedb/pathdb: optimize history indexing efficiency](https://github.com/ethereum/go-ethereum/pull/33303) - 2025-11-27
+* [Pull Request] [ethdb/pebble: add configuration changes](https://github.com/ethereum/go-ethereum/pull/33315) - 2025-11-28
+* [Pull Request] [core/state: export statistics to metrics](https://github.com/ethereum/go-ethereum/pull/33254) - 2025-12-02
+* [Pull Request] [ethdb/pebble: change the Pebble database configuration](https://github.com/ethereum/go-ethereum/pull/33353) - 2025-12-04
+* [Pull Request] [eth/downloader: keep current syncmode in downloader only](https://github.com/ethereum/go-ethereum/pull/33157) - 2025-12-08
+* [Pull Request] [triedb/pathdb: introduce extension to history index structure](https://github.com/ethereum/go-ethereum/pull/33399) - 2025-12-12
+* [Pull Request] [core, eth: add lock protection in snap sync](https://github.com/ethereum/go-ethereum/pull/33428) - 2025-12-16
+* [Pull Request] [eth/downloader: fix stale beacon header deletion](https://github.com/ethereum/go-ethereum/pull/33481) - 2025-12-23
 * [Pull Request] []() - 2025-12-30
-* [Pull Request] []() - 2025-12-31
+* [Pull Request] [eth/fetcher: improve the condition to stall peer in tx fetcher](https://github.com/ethereum/go-ethereum/pull/32725) - 2025-12-31
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2025-11-06
-* [Pull Request] []() - 2025-11-24
+* [Pull Request] [Update EIP-7610: Clarify the relationship between the EIP-7610 and EIP-7702](https://github.com/ethereum/EIPs/pull/10734) - 2025-11-06
+* [Pull Request] [Update EIP-7975: Update EIP-7975](https://github.com/ethereum/EIPs/pull/10825) - 2025-11-24
 ## Q3 2025
 
 

--- a/members/rjl493456442.md
+++ b/members/rjl493456442.md
@@ -19,6 +19,12 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 * [Pull Request] []() - 2026-02-19
 * [Pull Request] [core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816) - 2026-03-10
 * [Commit] [core, miner, tests: introduce codedb and simplify cachingDB (#33816)](https://github.com/ethereum/go-ethereum/commit/91cec92bf364525e03b9c449de26ab0b15cfe9b1) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3919331317) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3919334837) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3919336518) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3919340102) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3919355540) - 2026-03-10
+* [Review] [Review on: core, miner, tests: introduce codedb and simplify cachingDB](https://github.com/ethereum/go-ethereum/pull/33816#pullrequestreview-3919363605) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/rolfyone.md
+++ b/members/rolfyone.md
@@ -12,24 +12,24 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Arolfyo
 
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2026-01-19
+* [Pull Request] [removed original recovering sidecar retriever](https://github.com/Consensys/teku/pull/10280) - 2026-01-19
 * [Issue] ['please fix or report' in SidecarRetriever](https://github.com/Consensys/teku/issues/10288) - 2026-01-21
 * [Issue] [[EIP-7732] pubsub changes](https://github.com/Consensys/teku/issues/10301) - 2026-01-27
-* [Pull Request] []() - 2026-02-01
+* [Pull Request] [Refactored bls_to_execution validation](https://github.com/Consensys/teku/pull/10310) - 2026-02-01
 * [Issue] [cleanup the validation around bls_to_execution](https://github.com/Consensys/teku/issues/10309) - 2026-02-01
 * [Issue] [Boundary condition test for ForkChoiceUtilGloas](https://github.com/Consensys/teku/issues/10341) - 2026-02-06
 * [Issue] [fix voluntary exit test for gloas](https://github.com/Consensys/teku/issues/10340) - 2026-02-06
-* [Pull Request] []() - 2026-02-07
+* [Pull Request] [Implicitly default network-epochs](https://github.com/Consensys/teku/pull/10342) - 2026-02-07
 * [Issue] [[Beacon-api] implement proposers v2 endpoint](https://github.com/Consensys/teku/issues/10346) - 2026-02-09
 * [Issue] [proposer v1 endpoint post fulu](https://github.com/Consensys/teku/issues/10345) - 2026-02-09
 * [Issue] [grafana 'attestation performance' graph is overloaded](https://github.com/Consensys/teku/issues/10344) - 2026-02-08
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [reduced backfill default batch size to 3](https://github.com/Consensys/teku/pull/10356) - 2026-02-10
 * [Issue] [update besu library](https://github.com/Consensys/teku/issues/10364) - 2026-02-11
 * [Issue] [update discovery for teku](https://github.com/Consensys/teku/issues/10362) - 2026-02-11
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-15
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [updated some gloas entries for ethspecify](https://github.com/Consensys/teku/pull/10373) - 2026-02-12
+* [Pull Request] [fixed getProposerDuties compatibility with Electra](https://github.com/Consensys/teku/pull/10380) - 2026-02-15
+* [Pull Request] [fixed block dependent root calculation for fulu](https://github.com/Consensys/teku/pull/10384) - 2026-02-16
+* [Pull Request] [fixed parentPayloadStatus to be asynchronous](https://github.com/Consensys/teku/pull/10392) - 2026-02-20
 * [Issue] [[beacon-api] `POST /eth/v1/beacon/execution_payload_envelope` added   ](https://github.com/Consensys/teku/issues/10416) - 2026-02-25
 * [Issue] [[beacon-api] `GET /eth/v1/validator/execution_payload_envelope/{slot}` added](https://github.com/Consensys/teku/issues/10415) - 2026-02-25
 * [Issue] [[beacon-api] `GET /eth/v4/validator/blocks/{slot}` added ](https://github.com/Consensys/teku/issues/10414) - 2026-02-25
@@ -44,12 +44,23 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Arolfyo
 * [Issue] [[beacon-api] `POST /eth/v1/validator/duties/ptc/{epoch}`](https://github.com/Consensys/teku/issues/10405) - 2026-02-25
 * [Issue] [[beacon-api] `GET /eth/v1/validator/payload_attestation_data/{slot}`](https://github.com/Consensys/teku/issues/10404) - 2026-02-25
 * [Issue] [[beacon-api] `GET /eth/v1/validator/execution_payload_bid/{slot}/{builder_index}`](https://github.com/Consensys/teku/issues/10403) - 2026-02-25
-* [Pull Request] []() - 2026-02-26
+* [Pull Request] [adjusted duties slot for proposal duties](https://github.com/Consensys/teku/pull/10424) - 2026-02-26
 * [Issue] [[beacon-api] GetAttestationData - gloas optional committee index from api ](https://github.com/Consensys/teku/issues/10433) - 2026-02-27
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-08
-* [Pull Request] []() - 2026-03-10
+* [Pull Request] [Added gloas validations to GetAttestationData](https://github.com/Consensys/teku/pull/10432) - 2026-02-27
+* [Pull Request] [Added GetNewBlockV4 interface](https://github.com/Consensys/teku/pull/10437) - 2026-03-02
+* [Pull Request] [added benchmark for large state serialization](https://github.com/Consensys/teku/pull/10464) - 2026-03-08
+* [Pull Request] [Added deprecation warning for leveldb databases](https://github.com/Consensys/teku/pull/10468) - 2026-03-10
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [clarified migrate-database help](https://github.com/Consensys/teku/pull/10474) - 2026-03-11
+* [Pull Request] [added benchmark for large state serialization](https://github.com/Consensys/teku/pull/10464) - 2026-03-10
+* [Pull Request] [Updated post blocks description](https://github.com/Consensys/teku/pull/10419) - 2026-03-10
+* [Commit] [added benchmark for large state serialization (#10464)](https://github.com/Consensys/teku/commit/545c3f7b265bcd6e7b8420e0d099bff1106d7801) - 2026-03-10
+* [Commit] [Added deprecation warning for leveldb databases (#10468)](https://github.com/Consensys/teku/commit/1fd181c822a4d97c086444ffa0c60e729b542f98) - 2026-03-10
+* [Commit] [Updated post blocks description (#10419)](https://github.com/Consensys/teku/commit/f5040263e65942c8d17e6db360f7adc449f4ef3b) - 2026-03-10
+
+[libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p)
+* [Issue] [libp2p connection closed exception...](https://github.com/libp2p/jvm-libp2p/issues/452) - 2026-03-10
 ## Q4 2025
 
 
@@ -62,20 +73,20 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Arolfyo
 * [Pull Request] [wip rebuild columns](https://github.com/Consensys/teku/pull/9994) - 2025-10-10
 * [Issue] [fix fulu genesis state generation or test case](https://github.com/Consensys/teku/issues/10003) - 2025-10-13
 * [Pull Request] [Added testcase for getProposerIndices at fulu](https://github.com/Consensys/teku/pull/10000) - 2025-10-13
-* [Pull Request] []() - 2025-10-27
+* [Pull Request] [Revert "Rework custody/sampling count delivery (#9998)"](https://github.com/Consensys/teku/pull/10057) - 2025-10-27
 
-* [Pull Request] []() - 2025-10-29
+* [Pull Request] [implemented rest api proposer_lookahead for fulu](https://github.com/Consensys/teku/pull/10077) - 2025-10-29
 * [Issue] [implement proposer_lookahead endpoint](https://github.com/Consensys/teku/issues/10076) - 2025-10-29
 * [Issue] [CKZG4844PropertyTest takes ages](https://github.com/Consensys/teku/issues/10125) - 2025-11-12
-* [Pull Request] []() - 2025-11-24
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-01
+* [Pull Request] [Updated BeaconStateAccessorsFulu for proposer lookahead](https://github.com/Consensys/teku/pull/10162) - 2025-11-24
+* [Pull Request] [Revert "default the reworked recovery sidecar option to enabled"](https://github.com/Consensys/teku/pull/10187) - 2025-11-28
+* [Pull Request] [push cancellation message in das sampler to debug](https://github.com/Consensys/teku/pull/10194) - 2025-12-01
 * [Issue] [investigate falling back to v1 getPayload if the v2 fails](https://github.com/Consensys/teku/issues/10216) - 2025-12-09
 * [Issue] [concurrentModificationException in batch sync - `onNewPreImportBlocks`](https://github.com/Consensys/teku/issues/10223) - 2025-12-10
-* [Pull Request] []() - 2025-12-13
+* [Pull Request] [Revert "Add Single block provider for Fulu  (#10169)"](https://github.com/Consensys/teku/pull/10235) - 2025-12-13
 * [Issue] [[HOUSEKEEPING] cleanup CLI and old structures from reworked recovery task post 26.1.0](https://github.com/Consensys/teku/issues/10237) - 2025-12-14
-* [Pull Request] []() - 2025-12-14
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [added domain_bls_to_execution_change to spec output](https://github.com/Consensys/teku/pull/10236) - 2025-12-14
+* [Pull Request] [Defaulted the database version to v6](https://github.com/Consensys/teku/pull/10241) - 2025-12-15
 [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844)
 * [Issue] [segv when setting kzg-precompute to 15](https://github.com/ethereum/c-kzg-4844/issues/611) - 2025-10-28
 ## Q3 2025

--- a/members/rolfyone.md
+++ b/members/rolfyone.md
@@ -50,6 +50,9 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Arolfyo
 * [Pull Request] []() - 2026-03-02
 * [Pull Request] []() - 2026-03-08
 * [Pull Request] []() - 2026-03-10
+
+[libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p)
+* [Issue] [libp2p connection closed exception...](https://github.com/libp2p/jvm-libp2p/issues/452) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/rolfyone.md
+++ b/members/rolfyone.md
@@ -59,6 +59,13 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Arolfyo
 * [Commit] [Added deprecation warning for leveldb databases (#10468)](https://github.com/Consensys/teku/commit/1fd181c822a4d97c086444ffa0c60e729b542f98) - 2026-03-10
 * [Commit] [Updated post blocks description (#10419)](https://github.com/Consensys/teku/commit/f5040263e65942c8d17e6db360f7adc449f4ef3b) - 2026-03-10
 
+* [Review] [Review on: protoarray lookup optimization](https://github.com/Consensys/teku/pull/10448#pullrequestreview-3919474718) - 2026-03-10
+* [Review] [Review on: ci cleanup](https://github.com/Consensys/teku/pull/10466#pullrequestreview-3919532699) - 2026-03-10
+* [Review] [Review on: Engine api optimizations](https://github.com/Consensys/teku/pull/10469#pullrequestreview-3919291111) - 2026-03-10
+* [Review] [Review on: Add GET /eth/v1/beacon/pool/payload_attestations endpoint](https://github.com/Consensys/teku/pull/10465#pullrequestreview-3919349954) - 2026-03-10
+* [Review] [Review on: Add GET /eth/v1/beacon/pool/payload_attestations endpoint](https://github.com/Consensys/teku/pull/10465#pullrequestreview-3919386456) - 2026-03-10
+* [Review] [Review on: Add GET /eth/v1/beacon/pool/payload_attestations endpoint](https://github.com/Consensys/teku/pull/10465#pullrequestreview-3919393837) - 2026-03-10
+* [Review] [Review on: Implement `GET` `exceution_payload_bid` ](https://github.com/Consensys/teku/pull/10463#pullrequestreview-3919156453) - 2026-03-10
 [libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p)
 * [Issue] [libp2p connection closed exception...](https://github.com/libp2p/jvm-libp2p/issues/452) - 2026-03-10
 ## Q4 2025

--- a/members/rubo.md
+++ b/members/rubo.md
@@ -12,17 +12,24 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-11
+* [Pull Request] [Add AGENTS.md](https://github.com/NethermindEth/nethermind/pull/10177) - 2026-01-11
 
 * [Issue] [Implement input serialization for Zisk](https://github.com/NethermindEth/nethermind/issues/10633) - 2026-02-24
 * [Issue] [Consider using native Keccak in Zisk](https://github.com/NethermindEth/nethermind/issues/10632) - 2026-02-24
 * [Issue] [Resolve the instruction size issue in Zisk](https://github.com/NethermindEth/nethermind/issues/10631) - 2026-02-24
 * [Issue] [Implement precompiles for Zisk](https://github.com/NethermindEth/nethermind/issues/10630) - 2026-02-24
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-07
+* [Pull Request] [chore: Refactor `EthereumEcdsa`](https://github.com/NethermindEth/nethermind/pull/10698) - 2026-03-02
+* [Pull Request] [chore: Move `evm_benchmark_utils.py` to scripts](https://github.com/NethermindEth/nethermind/pull/10732) - 2026-03-05
+* [Pull Request] [Add PR tests concurrency rules](https://github.com/NethermindEth/nethermind/pull/10748) - 2026-03-07
 [nethermindeth/bflat-riscv64](https://github.com/nethermindeth/bflat-riscv64)
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [Add revised build workflow](https://github.com/NethermindEth/bflat-riscv64/pull/4) - 2026-02-09
+
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Pull Request] [chore: Update packages](https://github.com/NethermindEth/nethermind/pull/10774) - 2026-03-10
+* [Pull Request] [fix: Add new RLP decoders for zkEVM](https://github.com/NethermindEth/nethermind/pull/10773) - 2026-03-10
+* [Pull Request] [docs: Clarify guideline about infra](https://github.com/NethermindEth/nethermind/pull/10767) - 2026-03-10
+* [Commit] [fix: Add new RLP decoders for zkEVM (#10773)](https://github.com/NethermindEth/nethermind/commit/032f462634313fc159216a409e1ec252a20d63d0) - 2026-03-10
+* [Commit] [docs: Clarify guideline about infra (#10767)](https://github.com/NethermindEth/nethermind/commit/3a3e065a94084347357e8f33e1ec993c6ab0385d) - 2026-03-10
 ## Q4 2025
 
 
@@ -61,14 +68,14 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Commit] [test](https://github.com/NethermindEth/nethermind/commit/0e121f6230f6cce3ffc9f7a576c8bfe07e086429) - 2025-10-13
 * [Commit] [test](https://github.com/NethermindEth/nethermind/commit/9427b1b2cdbfa8187ed549a843a03bf6ea9020f5) - 2025-10-13
 * [Commit] [test](https://github.com/NethermindEth/nethermind/commit/3f28b61aee0efe3e8bf304208f4ccae6383c0346) - 2025-10-13
-* [Pull Request] []() - 2025-10-20
-* [Pull Request] []() - 2025-11-10
+* [Pull Request] [Fix fast sync settings workflow](https://github.com/NethermindEth/nethermind/pull/9519) - 2025-10-20
+* [Pull Request] [Remove Nethermind.Analytics](https://github.com/NethermindEth/nethermind/pull/9683) - 2025-11-10
 
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-22
-* [Pull Request] []() - 2025-12-26
+* [Pull Request] [Update packages](https://github.com/NethermindEth/nethermind/pull/9907) - 2025-12-09
+* [Pull Request] [Set release target commit explicitly](https://github.com/NethermindEth/nethermind/pull/10009) - 2025-12-22
+* [Pull Request] [Implement zkVM compatibility](https://github.com/NethermindEth/nethermind/pull/10048) - 2025-12-26
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-11-20
+* [Pull Request] [clients/nethermind: migrate to .net 10](https://github.com/ethereum/hive/pull/1371) - 2025-11-20
 ## Q3 2025
 
 

--- a/members/rubo.md
+++ b/members/rubo.md
@@ -30,6 +30,8 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Pull Request] [docs: Clarify guideline about infra](https://github.com/NethermindEth/nethermind/pull/10767) - 2026-03-10
 * [Commit] [fix: Add new RLP decoders for zkEVM (#10773)](https://github.com/NethermindEth/nethermind/commit/032f462634313fc159216a409e1ec252a20d63d0) - 2026-03-10
 * [Commit] [docs: Clarify guideline about infra (#10767)](https://github.com/NethermindEth/nethermind/commit/3a3e065a94084347357e8f33e1ec993c6ab0385d) - 2026-03-10
+* [Review] [Review on: ci: Add Claude review](https://github.com/NethermindEth/nethermind/pull/10768#pullrequestreview-3923191031) - 2026-03-10
+* [Review] [Review on: chore: add code review instructions for GitHub Copilot](https://github.com/NethermindEth/nethermind/pull/10602#pullrequestreview-3921405865) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/s1na.md
+++ b/members/s1na.md
@@ -15,20 +15,22 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 * [Issue] [Query transactions from era files on a pruned node](https://github.com/ethereum/go-ethereum/issues/33666) - 2026-01-22
 * [Issue] [eth_sendRawTransactionSync timeout parameter should be an int](https://github.com/ethereum/go-ethereum/issues/33696) - 2026-01-28
 
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [node: http2 for JSON-RPC API](https://github.com/ethereum/go-ethereum/pull/33812) - 2026-02-10
 * [Issue] [History expiry tracker](https://github.com/ethereum/go-ethereum/issues/33809) - 2026-02-10
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [internal/era: update eraE type IDs to match spec](https://github.com/ethereum/go-ethereum/pull/33827) - 2026-02-11
 * [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [docs: add page on using geth as a library](https://github.com/ethereum/go-ethereum/pull/33825) - 2026-02-16
+* [Pull Request] [internal/ethapi: fix gas cap for eth_simulateV1](https://github.com/ethereum/go-ethereum/pull/33952) - 2026-03-05
+* [Pull Request] [core/tracing: fix nonce revert edge case](https://github.com/ethereum/go-ethereum/pull/33978) - 2026-03-09
+* [Pull Request] [core/tracing: fix nonce revert edge case](https://github.com/ethereum/go-ethereum/pull/33978) - 2026-03-10
+* [Commit] [core/tracing: fix nonce revert edge case (#33978)](https://github.com/ethereum/go-ethereum/commit/aa417b03a6f9ef4f58c0e05c7eb1fde6a8db4894) - 2026-03-10
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [eth_simulateV1: fix revert err code](https://github.com/ethereum/execution-apis/pull/748) - 2026-02-05
+* [Pull Request] [transaction: add blockTimestamp](https://github.com/ethereum/execution-apis/pull/749) - 2026-02-06
 * [Issue] [eth_getStorageValues - Batch storage slot retrieval](https://github.com/ethereum/execution-apis/issues/752) - 2026-02-10
 * [Pull Request] []() - 2026-02-17
 * [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [eth: add getStorageValues method](https://github.com/ethereum/execution-apis/pull/756) - 2026-02-23
 ## Q4 2025
 
 
@@ -43,9 +45,9 @@ Team: [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%
 
 * [Issue] [Flaky TestUDPv4_smallNetConvergence hangs](https://github.com/ethereum/go-ethereum/issues/32863) - 2025-10-09
 * [Commit] [ethclient: add SubscribeTransactionReceipts (#32869)](https://github.com/ethereum/go-ethereum/commit/659342a52300d9cd8218face5528a91e7434a8fb) - 2025-10-10
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [internal/ethapi: fix error code for revert in eth_simulateV1](https://github.com/ethereum/go-ethereum/pull/33007) - 2025-10-23
+* [Pull Request] [internal/ethapi: change default tx type to 0x2](https://github.com/ethereum/go-ethereum/pull/33058) - 2025-10-30
+* [Pull Request] [Website: add arm64 build to downloads page](https://github.com/ethereum/go-ethereum/pull/33418) - 2025-12-15
 [ethereum/execution-apis](https://github.com/ethereum/execution-apis)
 * [Issue] [Proposal: eth_getCapabilities method](https://github.com/ethereum/execution-apis/issues/697) - 2025-10-09
 ## Q3 2025

--- a/members/samcm.md
+++ b/members/samcm.md
@@ -12,21 +12,21 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 
 
 [ethpandaops/xatu](https://github.com/ethpandaops/xatu)
-* [Pull Request] []() - 2026-01-12
-* [Pull Request] []() - 2026-01-15
-* [Pull Request] []() - 2026-01-23
+* [Pull Request] [feat(clickhouse): improve table and column comments across all tables](https://github.com/ethpandaops/xatu/pull/723) - 2026-01-12
+* [Pull Request] [feat: execution engine events](https://github.com/ethpandaops/xatu/pull/728) - 2026-01-15
+* [Pull Request] [feat(sentry): add blob sidecar fetching on block receipt](https://github.com/ethpandaops/xatu/pull/739) - 2026-01-23
 * [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [feat: Sentry Logs - Vector-based log collection for execution client metrics](https://github.com/ethpandaops/xatu/pull/742) - 2026-01-30
+* [Pull Request] [feat(clickhouse): initialize Observoor schema](https://github.com/ethpandaops/xatu/pull/745) - 2026-02-09
+* [Pull Request] [feat(sentry-logs): support all geth log formats](https://github.com/ethpandaops/xatu/pull/746) - 2026-02-12
 
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [fix(deps): upgrade vulnerable dependencies and add govulncheck CI](https://github.com/ethpandaops/xatu/pull/762) - 2026-02-20
+* [Pull Request] [refactor(consumoor): group batch processing by event type](https://github.com/ethpandaops/xatu/pull/787) - 2026-02-24
+* [Pull Request] [Release/consumoor](https://github.com/ethpandaops/xatu/pull/792) - 2026-02-25
 [ethpandaops/lab](https://github.com/ethpandaops/lab)
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [feat(xatu): add nodes section with resource monitoring](https://github.com/ethpandaops/lab/pull/421) - 2026-02-13
+* [Pull Request] [feat(node-resources): improve chart formatting and adapt to backend label changes](https://github.com/ethpandaops/lab/pull/424) - 2026-02-16
+* [Pull Request] [fix(consensus-overview): use flat page size to prevent truncation on dimensional data](https://github.com/ethpandaops/lab/pull/429) - 2026-02-23
 ## Q4 2025
 
 
@@ -38,15 +38,15 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Commit] [feat(migrations): add direction column to metadata status tables](https://github.com/ethpandaops/xatu/commit/a809040a9c3925b4b90a436cdcc945cbe8cc206a) - 2025-10-01
 * [Commit] [feat: replace kzg_commitments with kzg_commitments_count in data_column_sidecar](https://github.com/ethpandaops/xatu/commit/dce3bdf8df1436984738fabe5ed85b5795f28c35) - 2025-10-01
 * [Commit] [refactor(migration): drop and recreate distributed tables to include direction column](https://github.com/ethpandaops/xatu/commit/6d93a34da41d6404c19c7efa979cfdecfa403753) - 2025-10-01
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [feat(libp2p): Add rpc_custody_probe event](https://github.com/ethpandaops/xatu/pull/674) - 2025-10-15
 
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [feat(clmimicry): Add concrete types](https://github.com/ethpandaops/xatu/pull/692) - 2025-11-28
+* [Pull Request] [feat(libp2p): add raw peer_id columns to all libp2p tables](https://github.com/ethpandaops/xatu/pull/708) - 2025-12-11
+* [Pull Request] [feat(clmimicry): introduce random sampling for rejected events](https://github.com/ethpandaops/xatu/pull/711) - 2025-12-12
+* [Pull Request] [Add 0x prefix to hex-encoded fields in gossipsub sidecars](https://github.com/ethpandaops/xatu/pull/712) - 2025-12-15
 [ethpandaops/lab](https://github.com/ethpandaops/lab)
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-11-13
+* [Pull Request] [Add slots page](https://github.com/ethpandaops/lab/pull/165) - 2025-10-23
+* [Pull Request] [Fix offline validators chart calculation and display](https://github.com/ethpandaops/lab/pull/294) - 2025-11-13
 ## Q3 2025
 
 

--- a/members/samwilsn.md
+++ b/members/samwilsn.md
@@ -12,10 +12,10 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 
 
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-01-02
+* [Pull Request] [Website: Add a notice to the website and RSS feeds about upcoming migration](https://github.com/ethereum/EIPs/pull/11003) - 2026-01-02
 * [Issue] [Housekeeping Ideas](https://github.com/ethereum/EIPs/issues/11195) - 2026-01-28
 
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [Update LICENSE.md [ignore-me]](https://github.com/ethereum/EIPs/pull/11278) - 2026-02-06
 * [Issue] [Submit updated sitemap to Google / Bing / etc.](https://github.com/ethereum/EIPs/issues/11298) - 2026-02-10
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Carry pytest markers from Python all the way through to the filled JSON tests](https://github.com/ethereum/execution-specs/issues/2089) - 2026-01-28
@@ -25,8 +25,9 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Processes surrounding claude context files](https://github.com/ethereum/execution-specs/issues/2194) - 2026-02-11
 * [Issue] [Add test for decoding RLP -> `Uint` with leading zeros](https://github.com/ethereum/execution-specs/issues/2202) - 2026-02-12
 * [Issue] [Remove or generalize BAL's type alias](https://github.com/ethereum/execution-specs/issues/2260) - 2026-02-20
-* [Pull Request] []() - 2026-02-22
+* [Pull Request] [chore(specs): refactor BALs into one file; document it](https://github.com/ethereum/execution-specs/pull/2263) - 2026-02-22
 * [Issue] [Change EEST's `Address` equality to account for typing](https://github.com/ethereum/execution-specs/issues/2290) - 2026-02-23
+* [Pull Request] [chore(ci): don't close pull requests](https://github.com/ethereum/execution-specs/pull/2470) - 2026-03-10
 [ethereum/pm](https://github.com/ethereum/pm)
 * [Issue] [AllWalletDevs #38, February 18, 2026](https://github.com/ethereum/pm/issues/1909) - 2026-01-29
 ## Q4 2025
@@ -43,11 +44,11 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Add conventional commits linter](https://github.com/ethereum/execution-specs/issues/1461) - 2025-10-08
 * [Commit] [Update CONTRIBUTING.md to outline issue assignment practice (#1457)](https://github.com/ethereum/execution-specs/commit/6c99882c73315e23bc0ee7d613b9769f3807a3d5) - 2025-10-09
 * [Commit] [fixing issue #1398 (#1593)](https://github.com/ethereum/execution-specs/commit/a4aedae11b764d0be2d48900735558480151846a) - 2025-10-11
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [DRY-ify calculate_excess_blob_gas](https://github.com/ethereum/execution-specs/pull/1606) - 2025-10-15
 * [Issue] [Optimize the `json_infra` tests](https://github.com/ethereum/execution-specs/issues/1605) - 2025-10-15
 * [Issue] [Document conventional commit prefixes](https://github.com/ethereum/execution-specs/issues/1638) - 2025-10-20
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-11-24
+* [Pull Request] [enhance(spec-tool): create blob parameter-only hardforks on the fly](https://github.com/ethereum/execution-specs/pull/1789) - 2025-11-13
+* [Pull Request] [fix(spec-tests): missing fork criteria](https://github.com/ethereum/execution-specs/pull/1808) - 2025-11-24
 * [Issue] [Optimize json_infra collection when using `--tests-file`](https://github.com/ethereum/execution-specs/issues/1840) - 2025-12-03
 * [Issue] [Revisit how we implement glacier/bpo forks](https://github.com/ethereum/execution-specs/issues/1837) - 2025-12-03
 * [Issue] [Lint BPO forks in `ethereum-spec-lint`](https://github.com/ethereum/execution-specs/issues/1895) - 2025-12-10

--- a/members/samwilsn.md
+++ b/members/samwilsn.md
@@ -17,6 +17,9 @@ Team: [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 
 * [Pull Request] [Update LICENSE.md [ignore-me]](https://github.com/ethereum/EIPs/pull/11278) - 2026-02-06
 * [Issue] [Submit updated sitemap to Google / Bing / etc.](https://github.com/ethereum/EIPs/issues/11298) - 2026-02-10
+* [Review] [Review on: Add EIP: Binary SSZ Transport for the Engine API](https://github.com/ethereum/EIPs/pull/11365#pullrequestreview-3923879266) - 2026-03-10
+* [Review] [Review on: Add EIP: Binary SSZ Transport for the Engine API](https://github.com/ethereum/EIPs/pull/11365#pullrequestreview-3923888449) - 2026-03-10
+* [Review] [Review on: Add EIP: Composable Transaction](https://github.com/ethereum/EIPs/pull/11355#pullrequestreview-3923630290) - 2026-03-10
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [Carry pytest markers from Python all the way through to the filled JSON tests](https://github.com/ethereum/execution-specs/issues/2089) - 2026-01-28
 

--- a/members/satushh.md
+++ b/members/satushh.md
@@ -10,4 +10,4 @@ Github: [@satushh](https://github.com/satushh)
 
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-02-21
+* [Pull Request] [Ptc duty endpoint /eth/v1/validator/duties/ptc/{epoch} ](https://github.com/OffchainLabs/prysm/pull/16326) - 2026-02-21

--- a/members/sauliusgrigaitis.md
+++ b/members/sauliusgrigaitis.md
@@ -12,7 +12,7 @@ Team: Grandine
 
 
 [grandinetech/grandine](https://github.com/grandinetech/grandine)
-* [Pull Request] []() - 2026-02-27
+* [Pull Request] [Bumped Grandine version to 2.0.2](https://github.com/grandinetech/grandine/pull/616) - 2026-02-27
 ## Q4 2025
 
 
@@ -23,10 +23,10 @@ Team: Grandine
 * [Issue] [Upgrade rust-kzg](https://github.com/grandinetech/grandine/issues/408) - 2025-10-08
 * [Issue] [Duoble check the we don't have the vulnerabilities that were discovered in other clients during recent audits.](https://github.com/grandinetech/grandine/issues/407) - 2025-10-08
 * [Issue] [Fix exeption.log file path](https://github.com/grandinetech/grandine/issues/451) - 2025-10-30
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [Upgrade crates](https://github.com/grandinetech/grandine/pull/466) - 2025-11-05
 
 [ethereum/pm](https://github.com/ethereum/pm)
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [Update fusaka-mainnet-plan.md](https://github.com/ethereum/pm/pull/1830) - 2025-12-02
 ## Q3 2025
 
 

--- a/members/savid.md
+++ b/members/savid.md
@@ -12,27 +12,27 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 
 
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
-* [Pull Request] []() - 2026-01-05
+* [Pull Request] [ethstats: report newPayload processing time to stats server](https://github.com/ethereum/go-ethereum/pull/33395) - 2026-01-05
 
 [ethpandaops/lab](https://github.com/ethpandaops/lab)
-* [Pull Request] []() - 2026-01-06
-* [Pull Request] []() - 2026-01-08
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [fix(state-expiry): sort top 100 contracts by rank via API query](https://github.com/ethpandaops/lab/pull/371) - 2026-01-06
+* [Pull Request] [fix(contracts): normalize address to lowercase for API requests and relocate label-colors utility](https://github.com/ethpandaops/lab/pull/373) - 2026-01-08
+* [Pull Request] [chore(deps): update dependencies](https://github.com/ethpandaops/lab/pull/375) - 2026-01-14
 
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-20
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [feat: add 3xl/4xl breakpoints for ultrawide monitor support](https://github.com/ethpandaops/lab/pull/384) - 2026-01-19
+* [Pull Request] [transparent marklines and slightly transparent](https://github.com/ethpandaops/lab/pull/386) - 2026-01-20
+* [Pull Request] [chore: restructure CLAUDE.md and extract rules](https://github.com/ethpandaops/lab/pull/426) - 2026-02-18
 [ethpandaops/cartographoor](https://github.com/ethpandaops/cartographoor)
 * [Issue] [add new combined fork field](https://github.com/ethpandaops/cartographoor/issues/75) - 2026-01-15
 * [Issue] [add slot_duration_ms and slots_per_epoch to consensus layer forks](https://github.com/ethpandaops/cartographoor/issues/74) - 2026-01-15
 * [Issue] [automated fork info](https://github.com/ethpandaops/cartographoor/issues/73) - 2026-01-15
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [feat: add timestamps to forks and blob schedule](https://github.com/ethpandaops/cartographoor/pull/72) - 2026-01-15
 
 [ethpandaops/xatu](https://github.com/ethpandaops/xatu)
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [refactor(clickhouse): consolidate execution engine migrations](https://github.com/ethpandaops/xatu/pull/730) - 2026-01-16
+* [Pull Request] [feat(cannon): add sync committee deriver](https://github.com/ethpandaops/xatu/pull/743) - 2026-01-30
+* [Pull Request] [feat(cannon): add beacon block sync aggregate deriver](https://github.com/ethpandaops/xatu/pull/744) - 2026-02-05
+* [Pull Request] [feat: ch migration setup](https://github.com/ethpandaops/xatu/pull/793) - 2026-03-03
 ## Q4 2025
 
 
@@ -54,14 +54,14 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 * [Pull Request] [Release/state expiry](https://github.com/ethpandaops/lab/pull/119) - 2025-10-03
 * [Commit] [add block expiry window](https://github.com/ethpandaops/lab/commit/205a649008854260ea968f2a7247433c4a77060c) - 2025-10-06
 * [Pull Request] [refactor: massive frontend changes](https://github.com/ethpandaops/lab/pull/121) - 2025-10-10
-* [Pull Request] []() - 2025-10-24
+* [Pull Request] [refactor(theme): consolidate color system to CSS-first architecture](https://github.com/ethpandaops/lab/pull/173) - 2025-10-24
 
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [feat(execution): add state size page with daily data visualization](https://github.com/ethpandaops/lab/pull/344) - 2025-12-23
 [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum)
 * [Pull Request] []() - 2025-12-12
 
 [ethpandaops/xatu](https://github.com/ethpandaops/xatu)
-* [Pull Request] []() - 2025-12-18
+* [Pull Request] [feat(ethstats): add ethstats CLI subcommand with per-node credential forwarding](https://github.com/ethpandaops/xatu/pull/719) - 2025-12-18
 ## Q3 2025
 
 [ethpandaops/xatu](https://github.com/ethpandaops/xatu)

--- a/members/scottypoi.md
+++ b/members/scottypoi.md
@@ -13,18 +13,18 @@ Team: EthereumJS
 
 [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo)
 * [Issue] [Refactor naming conventions to improve usability for AI-assisted tooling](https://github.com/ethereumjs/ethereumjs-monorepo/issues/4218) - 2026-01-08
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-13
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [block: use child common in EIP-7918 reserve price check](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4217) - 2026-01-07
+* [Pull Request] [update bundle size script](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4220) - 2026-01-09
+* [Pull Request] [execution-spec-tests runners](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4207) - 2026-01-13
+* [Pull Request] [vm.runBlock: revert state changes if header validation fails](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4227) - 2026-01-15
 * [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-20
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-19
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-28
+* [Pull Request] [VM: throw if system contract calls fail](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4232) - 2026-01-20
+* [Pull Request] [Pass filename or partial path to execution-spec-tests loader](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4237) - 2026-01-28
+* [Pull Request] [Spec test runner: improve error message](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4236) - 2026-01-29
+* [Pull Request] [EIP-7778: Block-Level Gas Accounting without Refunds](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4244) - 2026-02-18
+* [Pull Request] [BAL transition bug fix](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4245) - 2026-02-19
+* [Pull Request] [Implement EIP-7778 + EIP-8024 (with EIP-663 cleanup)](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4248) - 2026-02-25
+* [Pull Request] [Misc Amsterdam eip fixes](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4251) - 2026-02-28
 * [Pull Request] []() - 2026-03-04
 ## Q4 2025
 
@@ -33,18 +33,18 @@ Team: EthereumJS
 * [Pull Request] [update weight to PT](https://github.com/protocolguild/documentation/pull/431) - 2025-10-06
 
 [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo)
-* [Pull Request] []() - 2025-10-15
+* [Pull Request] [cleanup unused dependencies and fix dependency categorization](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4146) - 2025-10-15
 * [Issue] [common: hardforks() method has dead code](https://github.com/ethereumjs/ethereumjs-monorepo/issues/4159) - 2025-10-21
-* [Pull Request] []() - 2025-10-24
-* [Pull Request] []() - 2025-10-29
+* [Pull Request] [tx: throw on toCreationAddress for 4844 and 7702](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4162) - 2025-10-24
+* [Pull Request] [Testdata: Signers](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4167) - 2025-10-29
 
-* [Pull Request] []() - 2025-11-06
-* [Pull Request] []() - 2025-11-08
-* [Pull Request] []() - 2025-12-02
-* [Pull Request] []() - 2025-12-19
-* [Pull Request] []() - 2025-12-24
+* [Pull Request] [block: proofread README and typedoc comments](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4173) - 2025-11-06
+* [Pull Request] [evm: p256verify precompile example](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4177) - 2025-11-08
+* [Pull Request] [Fix vm nightly](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4205) - 2025-12-02
+* [Pull Request] [vm: remove unused devDependency](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4208) - 2025-12-19
+* [Pull Request] [Fix-accumulateRequests](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4211) - 2025-12-24
 [ethereumjs/ultralight](https://github.com/ethereumjs/ultralight)
-* [Pull Request] []() - 2025-10-30
+* [Pull Request] [Rename Legacy networks](https://github.com/ethereumjs/ultralight/pull/796) - 2025-10-30
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [eip7594 test: expected_exception mismatch](https://github.com/ethereum/execution-specs/issues/1916) - 2025-12-12

--- a/members/shekhirin.md
+++ b/members/shekhirin.md
@@ -12,12 +12,12 @@ Team: Reth
 
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-07
+* [Pull Request] [Add Brian Picciano from Reth](https://github.com/protocolguild/documentation/pull/460) - 2026-01-07
 
 [paradigmxyz/reth](https://github.com/paradigmxyz/reth)
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-21
-* [Pull Request] []() - 2026-03-05
+* [Pull Request] [ci(bench): ABBA run order](https://github.com/paradigmxyz/reth/pull/22335) - 2026-02-18
+* [Pull Request] [[autoopt] Amortize MDBX transaction timeout checking to reduce Cell::get overhead](https://github.com/paradigmxyz/reth/pull/22464) - 2026-02-21
+* [Pull Request] [feat(reth-bench): `--reorg` flag](https://github.com/paradigmxyz/reth/pull/22818) - 2026-03-05
 ## Q4 2025
 
 
@@ -40,18 +40,18 @@ Team: Reth
 * [Commit] [ci: remove reproducible build from release.yml](https://github.com/paradigmxyz/reth/commit/eef09eff41289a4e9fcaca261a94b61c914b7024) - 2025-10-13
 * [Issue] [TransactionHashNumbers static files segment](https://github.com/paradigmxyz/reth/issues/19035) - 2025-10-15
 * [Issue] [Support pushing Prometheus metrics to a remote URL](https://github.com/paradigmxyz/reth/issues/19229) - 2025-10-22
-* [Pull Request] []() - 2025-10-24
+* [Pull Request] [feat(tracing): set default OTLP log level to WARN](https://github.com/paradigmxyz/reth/pull/19283) - 2025-10-24
 * [Issue] [Payload validator cleanup after `ConsistentDbView` removal](https://github.com/paradigmxyz/reth/issues/19341) - 2025-10-28
-* [Pull Request] []() - 2025-11-01
+* [Pull Request] [refactor(provider, cli): simplify getting provider for index or range](https://github.com/paradigmxyz/reth/pull/19440) - 2025-11-01
 * [Issue] [Make sure that we can just delete static files and it will not break provider access](https://github.com/paradigmxyz/reth/issues/19589) - 2025-11-07
-* [Pull Request] []() - 2025-11-08
-* [Pull Request] []() - 2025-11-15
+* [Pull Request] [refactor(provider): introduce `EitherWriter::new_receipts`](https://github.com/paradigmxyz/reth/pull/19600) - 2025-11-08
+* [Pull Request] [refactor(provider): `EitherWriter::prune_receipts`](https://github.com/paradigmxyz/reth/pull/19772) - 2025-11-15
 * [Issue] [Tracing performance degradation](https://github.com/paradigmxyz/reth/issues/20058) - 2025-12-01
 * [Issue] [Make TxPoolArgs defaults customizable](https://github.com/paradigmxyz/reth/issues/20098) - 2025-12-03
 * [Issue] [Use depot for Docker CI workflows](https://github.com/paradigmxyz/reth/issues/20239) - 2025-12-09
 * [Issue] [Use sccache in CI](https://github.com/paradigmxyz/reth/issues/20238) - 2025-12-09
 * [Issue] [Recover senders for imported network transactions in a blocking task](https://github.com/paradigmxyz/reth/issues/20271) - 2025-12-10
-* [Pull Request] []() - 2025-12-10
+* [Pull Request] [ci: sccache](https://github.com/paradigmxyz/reth/pull/20265) - 2025-12-10
 * [Issue] [Make RpcServerArgs defaults customizable](https://github.com/paradigmxyz/reth/issues/20305) - 2025-12-11
 * [Issue] [Measure and maybe cache precompile cache initialization in payload execution](https://github.com/paradigmxyz/reth/issues/20439) - 2025-12-16
 * [Issue] [Remove fork detection logic in insert_block](https://github.com/paradigmxyz/reth/issues/20438) - 2025-12-16
@@ -65,7 +65,7 @@ Team: Reth
 * [Issue] [Add thread names for spawned blocking tasks](https://github.com/paradigmxyz/reth/issues/20430) - 2025-12-16
 
 [bluealloy/revm](https://github.com/bluealloy/revm)
-* [Pull Request] []() - 2025-12-17
+* [Pull Request] [perf(database): avoid triple cache lookup](https://github.com/bluealloy/revm/pull/3232) - 2025-12-17
 ## Q3 2025
 
 

--- a/members/shekhirin.md
+++ b/members/shekhirin.md
@@ -18,6 +18,11 @@ Team: Reth
 * [Pull Request] [ci(bench): ABBA run order](https://github.com/paradigmxyz/reth/pull/22335) - 2026-02-18
 * [Pull Request] [[autoopt] Amortize MDBX transaction timeout checking to reduce Cell::get overhead](https://github.com/paradigmxyz/reth/pull/22464) - 2026-02-21
 * [Pull Request] [feat(reth-bench): `--reorg` flag](https://github.com/paradigmxyz/reth/pull/22818) - 2026-03-05
+* [Review] [Review on: feat: enable PGO in release and docker workflows](https://github.com/paradigmxyz/reth/pull/21441#pullrequestreview-3926062921) - 2026-03-10
+* [Review] [Review on: fix(ci): remove issue_comment: edited from bench trigger](https://github.com/paradigmxyz/reth/pull/22925#pullrequestreview-3923553339) - 2026-03-10
+* [Review] [Review on: ci(bench): add metrics proxy with subnet binding and tracy upload](https://github.com/paradigmxyz/reth/pull/22752#pullrequestreview-3924097803) - 2026-03-10
+* [Review] [Review on: chore: rm thunderdome refs](https://github.com/paradigmxyz/reth/pull/22927#pullrequestreview-3924639209) - 2026-03-10
+* [Review] [Review on: fix(bench): retry HTTP 502 errors in block provider](https://github.com/paradigmxyz/reth/pull/22916#pullrequestreview-3921972122) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/shohamc1.md
+++ b/members/shohamc1.md
@@ -12,7 +12,7 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-27
+* [Pull Request] [Make `lastCommittedTxNum` atomic](https://github.com/erigontech/erigon/pull/18820) - 2026-01-27
 ## Q4 2025
 
 

--- a/members/siladu.md
+++ b/members/siladu.md
@@ -26,6 +26,7 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asi
 * [Issue] [Bump GHAs to Ubuntu 24.04](https://github.com/hyperledger/besu/issues/9949) - 2026-03-03
 * [Pull Request] [Benchmarking docs](https://github.com/besu-eth/besu/pull/9998) - 2026-03-09
 * [Pull Request] [Use existing RLP methods in trie log prune batch files](https://github.com/besu-eth/besu/pull/10009) - 2026-03-10
+* [Review] [Review on: enable local gradle caching ](https://github.com/besu-eth/besu/pull/10008#pullrequestreview-3919946351) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/siladu.md
+++ b/members/siladu.md
@@ -12,31 +12,32 @@ Team: [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asi
 
 
 [protocolguild/documentation](https://github.com/protocolguild/documentation)
-* [Pull Request] []() - 2026-01-01
+* [Pull Request] [Add Karim Taam to Besu](https://github.com/protocolguild/documentation/pull/451) - 2026-01-01
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
 * [Issue] [Receipt Root Mismatch Causing Chain Halt](https://github.com/hyperledger/besu/issues/9610) - 2026-01-08
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [Replace BytesTrieSet with HashSet](https://github.com/besu-eth/besu/pull/9641) - 2026-01-15
 * [Issue] [Investigate debug_stateSize](https://github.com/hyperledger/besu/issues/9658) - 2026-01-20
-* [Pull Request] []() - 2026-02-12
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [Support substring and glob matching for --test-name in block-test](https://github.com/besu-eth/besu/pull/9790) - 2026-02-12
+* [Pull Request] [Fix jmh task](https://github.com/besu-eth/besu/pull/9798) - 2026-02-13
+* [Pull Request] [Use docker buildx imagetools for multi-arch manifest creation](https://github.com/besu-eth/besu/pull/9819) - 2026-02-17
 * [Issue] [Use docker buildx imagetools for multi-arch manifest creation](https://github.com/hyperledger/besu/issues/9818) - 2026-02-17
 * [Issue] [Replace JSR305 (javax.annotation) and checker-qual annotations with modern equivalents](https://github.com/hyperledger/besu/issues/9917) - 2026-02-27
 * [Issue] [Bump GHAs to Ubuntu 24.04](https://github.com/hyperledger/besu/issues/9949) - 2026-03-03
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Benchmarking docs](https://github.com/besu-eth/besu/pull/9998) - 2026-03-09
+* [Pull Request] [Use existing RLP methods in trie log prune batch files](https://github.com/besu-eth/besu/pull/10009) - 2026-03-10
 ## Q4 2025
 
 
 [hyperledger/besu](https://github.com/hyperledger/besu)
 * [Commit] [fix: clear tx blob map when pool is disabled (#9211)](https://github.com/hyperledger/besu/commit/efa9b43f79f918451b0da4197a47ea0b49f11f87) - 2025-10-09
 * [Issue] [Release 25.10.0-RC3](https://github.com/hyperledger/besu/issues/9302) - 2025-10-14
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-11-17
+* [Pull Request] [Fix flakiness by setting up block processors before each test](https://github.com/besu-eth/besu/pull/9351) - 2025-10-23
+* [Pull Request] [Optimise engine_getPayload* and engine_getBlobsV2](https://github.com/besu-eth/besu/pull/9445) - 2025-11-17
 
-* [Pull Request] []() - 2025-12-22
+* [Pull Request] [eth_config showAllForks prototype](https://github.com/besu-eth/besu/pull/9593) - 2025-12-22
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2025-12-01
+* [Pull Request] [Increase besu http timeout to 11 minutes](https://github.com/NethermindEth/gas-benchmarks/pull/80) - 2025-12-01
 * [Pull Request] []() - 2025-12-10
 ## Q3 2025
 

--- a/members/skylenet.md
+++ b/members/skylenet.md
@@ -12,13 +12,13 @@ Team: [ethPandaOps](https://github.com/ethpandaops)
 
 
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [fix: update volume path for geth datadir](https://github.com/NethermindEth/gas-benchmarks/pull/119) - 2026-02-13
 ## Q4 2025
 
 
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-11-13
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [go.mod: upgrade to github.com/fsouza/go-dockerclient v1.12.2](https://github.com/ethereum/hive/pull/1370) - 2025-11-13
+* [Pull Request] [internal/libdocker: remove deprecated CheckDuplicate field in CreateNetwork](https://github.com/ethereum/hive/pull/1374) - 2025-12-02
 ## Q3 2025
 
 

--- a/members/smartprogrammer93.md
+++ b/members/smartprogrammer93.md
@@ -20,6 +20,7 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 * [Pull Request] [ci: Add Claude review](https://github.com/NethermindEth/nethermind/pull/10768) - 2026-03-10
 * [Pull Request] [feat(jsonrpc): add eth_subscribe transactionReceipts subscription](https://github.com/NethermindEth/nethermind/pull/10524) - 2026-03-10
 * [Commit] [feat(jsonrpc): add eth_subscribe transactionReceipts subscription (#10524)](https://github.com/NethermindEth/nethermind/commit/a916b0e2495ab0a0901da32b25a49a0a9c7430a3) - 2026-03-10
+* [Review] [Review on: ci: Add Claude review](https://github.com/NethermindEth/nethermind/pull/10768#pullrequestreview-3923681880) - 2026-03-10
 ## Q3 2025
 
 

--- a/members/smartprogrammer93.md
+++ b/members/smartprogrammer93.md
@@ -12,9 +12,14 @@ Team: [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pul
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-01-03
-* [Pull Request] []() - 2026-02-07
+* [Pull Request] [fix: ensure eth_getBlockByNumber enforces canonical block retrieval](https://github.com/NethermindEth/nethermind/pull/10024) - 2026-01-03
+* [Pull Request] [refactor: additional unused code cleanup](https://github.com/NethermindEth/nethermind/pull/10445) - 2026-02-07
 * [Issue] [`eth_estimateGas` intermittently returns incorrect results / reverts on v1.36.0 (regression from v1.35.x)](https://github.com/NethermindEth/nethermind/issues/10552) - 2026-02-17
+
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Pull Request] [ci: Add Claude review](https://github.com/NethermindEth/nethermind/pull/10768) - 2026-03-10
+* [Pull Request] [feat(jsonrpc): add eth_subscribe transactionReceipts subscription](https://github.com/NethermindEth/nethermind/pull/10524) - 2026-03-10
+* [Commit] [feat(jsonrpc): add eth_subscribe transactionReceipts subscription (#10524)](https://github.com/NethermindEth/nethermind/commit/a916b0e2495ab0a0901da32b25a49a0a9c7430a3) - 2026-03-10
 ## Q3 2025
 
 

--- a/members/spencer-tb.md
+++ b/members/spencer-tb.md
@@ -12,16 +12,23 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 
 
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
-* [Pull Request] []() - 2026-01-23
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [feat(ci): update inputs for ci rebase/merge workflows](https://github.com/ethereum/execution-specs/pull/2072) - 2026-01-23
+* [Pull Request] [[DEPRECATED] - feat(tests): add eip-8037 state gas support to amsterdam tests and framework](https://github.com/ethereum/execution-specs/pull/2235) - 2026-02-18
 
 * [Issue] [refactor(tests): replace manual intrinsic gas arithmetic broken by EIP-7976/EIP-7981 repricing](https://github.com/ethereum/execution-specs/issues/2289) - 2026-02-23
+* [Pull Request] [feat(tests): add tests for address not warmed on aborted create](https://github.com/ethereum/execution-specs/pull/2452) - 2026-03-10
+* [Pull Request] [feat(tests,spec-specs): code deposit ordering and regression tests](https://github.com/ethereum/execution-specs/pull/2468) - 2026-03-10
+* [Pull Request] [feat(tests): add missing legacy modexp cases with oversized lengths](https://github.com/ethereum/execution-specs/pull/2447) - 2026-03-10
+* [Pull Request] [feat(ci): update inputs for ci rebase/merge workflows](https://github.com/ethereum/execution-specs/pull/2072) - 2026-03-10
+* [Commit] [feat(tests): add tests for address not warmed on aborted create (#2452)](https://github.com/ethereum/execution-specs/commit/8a0fc6993eaf636580fefdf838712b5392bc6aae) - 2026-03-10
+* [Commit] [feat(tests): add missing legacy modexp cases with oversized lengths (#2447)](https://github.com/ethereum/execution-specs/commit/d581f26c08497786f446b26236eacf4a721e2d4a) - 2026-03-10
+* [Commit] [feat(ci): update inputs for ci rebase/merge workflows (#2072)](https://github.com/ethereum/execution-specs/commit/3975d16d906f52cdbf50fc1a70df8b45213b9c10) - 2026-03-10
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [simulators: remove obsolete consensus, graphql, testnet, portal, and clique simulators](https://github.com/ethereum/hive/pull/1388) - 2026-02-20
 
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [hiveview: show suites with empty simLog value when running dev mode](https://github.com/ethereum/hive/pull/1400) - 2026-03-09
 [ethereum/eips](https://github.com/ethereum/eips)
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [Update EIP-8037: clarify reservoir mechanics](https://github.com/ethereum/EIPs/pull/11328) - 2026-03-06
 ## Q4 2025
 
 
@@ -54,7 +61,7 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Commit] [feat(tests): test call for eip2929 (#689)](https://github.com/ethereum/execution-spec-tests/commit/8115621105b79f60f0228f17c769d2af1db56562) - 2025-10-09
 * [Commit] [chore(docs): bump changelog for 5.3.0.](https://github.com/ethereum/execution-spec-tests/commit/2f21d20345f15ee2a57dc6c2e1d32d493af574d1) - 2025-10-09
 * [Commit] [feat(checklists,tests): complete eip7934 checklist + update checklist template + add missing test cases (#2282)](https://github.com/ethereum/execution-spec-tests/commit/eda8cc67c4c47d56effd231a171ca95bc90d7e1e) - 2025-10-09
-* [Pull Request] []() - 2025-10-17
+* [Pull Request] [feat(consume): consume block production hive simulator](https://github.com/ethereum/execution-spec-tests/pull/2307) - 2025-10-17
 [ethereum/execution-specs](https://github.com/ethereum/execution-specs)
 * [Issue] [feat(fw|evm): update t8n pipeline to allow tests to use invalid fields](https://github.com/ethereum/execution-specs/issues/1485) - 2025-10-09
 * [Issue] [feat(consume): add client config files to EEST](https://github.com/ethereum/execution-specs/issues/1484) - 2025-10-09
@@ -63,13 +70,13 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Issue] [Fix unhandled modexp U256 overflow for forks before Osaka](https://github.com/ethereum/execution-specs/issues/1465) - 2025-10-09
 * [Pull Request] [feat(ci): integrate EEST CI into EELS (WIP)](https://github.com/ethereum/execution-specs/pull/1598) - 2025-10-13
 
-* [Pull Request] []() - 2025-10-21
-* [Pull Request] []() - 2025-12-07
+* [Pull Request] [chore(tooling): add initial vscode settings](https://github.com/ethereum/execution-specs/pull/1650) - 2025-10-21
+* [Pull Request] [chore(ci): updates for final osaka test release](https://github.com/ethereum/execution-specs/pull/1845) - 2025-12-07
 [ethereum/evmone](https://github.com/ethereum/evmone)
 * [Issue] [Remaining fails filling EEST with evmone](https://github.com/ipsilon/evmone/issues/1337) - 2025-10-14
 
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [simulators/eels: fix `execute-blobs` simulator](https://github.com/ethereum/hive/pull/1365) - 2025-10-28
 ## Q3 2025
 
 

--- a/members/spencer-tb.md
+++ b/members/spencer-tb.md
@@ -23,6 +23,8 @@ Team: [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec
 * [Commit] [feat(tests): add tests for address not warmed on aborted create (#2452)](https://github.com/ethereum/execution-specs/commit/8a0fc6993eaf636580fefdf838712b5392bc6aae) - 2026-03-10
 * [Commit] [feat(tests): add missing legacy modexp cases with oversized lengths (#2447)](https://github.com/ethereum/execution-specs/commit/d581f26c08497786f446b26236eacf4a721e2d4a) - 2026-03-10
 * [Commit] [feat(ci): update inputs for ci rebase/merge workflows (#2072)](https://github.com/ethereum/execution-specs/commit/3975d16d906f52cdbf50fc1a70df8b45213b9c10) - 2026-03-10
+* [Review] [Review on: feat(test-consume): initial implementation of the enginex simulator](https://github.com/ethereum/execution-specs/pull/1964#pullrequestreview-3921972963) - 2026-03-10
+* [Review] [Review on: feat(tests): port goevmlab regression tests for EELS consensus bugs ](https://github.com/ethereum/execution-specs/pull/2457#pullrequestreview-3923481734) - 2026-03-10
 [ethereum/hive](https://github.com/ethereum/hive)
 * [Pull Request] [simulators: remove obsolete consensus, graphql, testnet, portal, and clique simulators](https://github.com/ethereum/hive/pull/1388) - 2026-02-20
 

--- a/members/spiral-ladder.md
+++ b/members/spiral-ladder.md
@@ -25,5 +25,7 @@ Github: [@spiral-ladder](https://github.com/spiral-ladder)
 * [Pull Request] []() - 2026-02-25
 * [Pull Request] []() - 2026-03-04
 * [Pull Request] []() - 2026-03-06
+* [Pull Request] []() - 2026-03-10
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
 * [Pull Request] []() - 2026-02-13
+* [Issue] [EIP-8025: optional execution proofs](https://github.com/ChainSafe/lodestar/issues/9016) - 2026-03-10

--- a/members/spiral-ladder.md
+++ b/members/spiral-ladder.md
@@ -10,20 +10,25 @@ Github: [@spiral-ladder](https://github.com/spiral-ladder)
 
 
 [chainsafe/lodestar-z](https://github.com/chainsafe/lodestar-z)
-* [Pull Request] []() - 2026-01-26
-* [Pull Request] []() - 2026-01-28
-* [Pull Request] []() - 2026-01-30
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-04
+* [Pull Request] [feat: blst bindings](https://github.com/ChainSafe/lodestar-z/pull/192) - 2026-01-26
+* [Pull Request] [(do not merge) comptime fn name guarantees for napi bindings](https://github.com/ChainSafe/lodestar-z/pull/198) - 2026-01-28
+* [Pull Request] [refactor: extract napi_property_descriptro helpers](https://github.com/ChainSafe/lodestar-z/pull/201) - 2026-01-30
+* [Pull Request] [feat(napi): extend blst bindings](https://github.com/ChainSafe/lodestar-z/pull/204) - 2026-02-02
+* [Pull Request] [docs(styleguide): looser memory allocation strategy](https://github.com/ChainSafe/lodestar-z/pull/207) - 2026-02-03
+* [Pull Request] [refactor(napi): derive fork instead of using from param in `BeaconStateView_createFromBytes`](https://github.com/ChainSafe/lodestar-z/pull/205) - 2026-02-04
 * [Pull Request] []() - 2026-02-05
 * [Issue] [bindings: investigate long timeout for `hashTreeRoot` test](https://github.com/ChainSafe/lodestar-z/issues/212) - 2026-02-10
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [feat(napi): metrics bindings](https://github.com/ChainSafe/lodestar-z/pull/211) - 2026-02-10
+* [Pull Request] [refactor: effective balance increments](https://github.com/ChainSafe/lodestar-z/pull/213) - 2026-02-11
 
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [fix: make `verify_signatures` default to `false` for `TransitionOpt`](https://github.com/ChainSafe/lodestar-z/pull/221) - 2026-02-24
+* [Pull Request] [feat: fixes to allow lodestar integration](https://github.com/ChainSafe/lodestar-z/pull/218) - 2026-02-25
+* [Pull Request] [refactor(epoch-cache): ownership of `active_indices`](https://github.com/ChainSafe/lodestar-z/pull/229) - 2026-03-04
+* [Pull Request] [feat: mt verify with benchmarks](https://github.com/ChainSafe/lodestar-z/pull/231) - 2026-03-06
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
-* [Pull Request] []() - 2026-02-13
+* [Pull Request] [feat(blst): replace `blst` and `pubkeys` with `lodestar-z`](https://github.com/ChainSafe/lodestar/pull/8900) - 2026-02-13
+[ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
+* [Issue] [EIP-8025: optional execution proofs](https://github.com/ChainSafe/lodestar/issues/9016) - 2026-03-10
+
+[ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z)
+* [Pull Request] [[DO NOT MERGE] native mt + bench all 3 approaches](https://github.com/ChainSafe/lodestar-z/pull/234) - 2026-03-10

--- a/members/stdevmac.md
+++ b/members/stdevmac.md
@@ -10,4 +10,7 @@ Github: [@stdevmac](https://github.com/stdevmac)
 
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [feat: add ci reporter action](https://github.com/NethermindEth/nethermind/pull/10564) - 2026-02-17
+[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind)
+* [Pull Request] [Fix assertoor workflow: bump setup-python to v6](https://github.com/NethermindEth/nethermind/pull/10645) - 2026-03-10
+* [Commit] [Fix assertoor workflow: bump setup-python to v6 (#10645)](https://github.com/NethermindEth/nethermind/commit/40cae116750ad0837d45caf37ed4ab8e82e884e4) - 2026-03-10

--- a/members/stefanbratanov.md
+++ b/members/stefanbratanov.md
@@ -12,20 +12,24 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3AStefan
 
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2026-01-05
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [Containers and config for non-validating staked builders](https://github.com/Consensys/teku/pull/10257) - 2026-01-05
+* [Pull Request] [Make builders non-validating staked actors](https://github.com/Consensys/teku/pull/10261) - 2026-01-06
 * [Issue] [Implement proposer preferences](https://github.com/Consensys/teku/issues/10259) - 2026-01-06
-* [Pull Request] []() - 2026-01-08
-* [Pull Request] []() - 2026-01-30
+* [Pull Request] [Fork choice changes to align with `v1.7.0-alpha.1`](https://github.com/Consensys/teku/pull/10263) - 2026-01-08
+* [Pull Request] [Prune hot collections correctly](https://github.com/Consensys/teku/pull/10308) - 2026-01-30
 * [Pull Request] []() - 2026-02-02
 * [Issue] [DoS prevention measures for p2p bids](https://github.com/Consensys/teku/issues/10314) - 2026-02-02
 * [Issue] [Data availability checks in Gloas](https://github.com/Consensys/teku/issues/10311) - 2026-02-02
 * [Issue] [Proposer Boost Changes](https://github.com/Consensys/teku/issues/10320) - 2026-02-03
 * [Issue] [[Gloas] State Selection during Block Production](https://github.com/Consensys/teku/issues/10352) - 2026-02-09
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [Add barebone Heze fork](https://github.com/Consensys/teku/pull/10398) - 2026-02-23
+* [Pull Request] [[Gloas] Make devnet-0 happy](https://github.com/Consensys/teku/pull/10422) - 2026-02-25
 * [Pull Request] []() - 2026-02-28
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [[Gloas] Cache early received payload for future processing](https://github.com/Consensys/teku/pull/10440) - 2026-03-02
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [[Gloas] fCu and attestation index changes for devnet-0](https://github.com/Consensys/teku/pull/10445) - 2026-03-10
+* [Commit] [[Gloas] fCu and attestation index changes for devnet-0 (#10445)](https://github.com/Consensys/teku/commit/bfbc348300f1a72d569d71032001c5aa44ef003e) - 2026-03-10
 ## Q4 2025
 
 
@@ -48,20 +52,20 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3AStefan
 * [Issue] [Split integration tests](https://github.com/Consensys/teku/issues/10007) - 2025-10-13
 * [Issue] [Delay when producing an execution payload in Gloas (self-built)](https://github.com/Consensys/teku/issues/10018) - 2025-10-15
 * [Issue] [Payload timeliness attestation duty](https://github.com/Consensys/teku/issues/10041) - 2025-10-21
-* [Pull Request] []() - 2025-10-22
+* [Pull Request] [Fork choice `on_execution_payload` skeleton](https://github.com/Consensys/teku/pull/10049) - 2025-10-22
 * [Issue] [Adapt `TimeBasedEventAdapter` for Gloas](https://github.com/Consensys/teku/issues/10053) - 2025-10-23
 
-* [Pull Request] []() - 2025-10-30
-* [Pull Request] []() - 2025-11-01
+* [Pull Request] [Update ref tests to v1.6.0-beta.2](https://github.com/Consensys/teku/pull/10081) - 2025-10-30
+* [Pull Request] [Upgrade to stable v1.6.0 reference tests release](https://github.com/Consensys/teku/pull/10091) - 2025-11-01
 * [Issue] [Investigate usages of `BlockBlobSidecarsTrackersPool` ](https://github.com/Consensys/teku/issues/10101) - 2025-11-05
-* [Pull Request] []() - 2025-11-11
-* [Pull Request] []() - 2025-11-15
-* [Pull Request] []() - 2025-12-08
+* [Pull Request] [Payload attestation messages aggregation during block proposal](https://github.com/Consensys/teku/pull/10121) - 2025-11-11
+* [Pull Request] [Gloas changes for `v1.6.1`](https://github.com/Consensys/teku/pull/10141) - 2025-11-15
+* [Pull Request] [Fix `BlobSidecarSelectorFactory` for Gloas](https://github.com/Consensys/teku/pull/10209) - 2025-12-08
 * [Pull Request] []() - 2025-12-27
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [Add pending payment withdrawal epoch asserts](https://github.com/ethereum/consensus-specs/pull/4701) - 2025-10-28
 * [Issue] [Add fork tests for Gloas](https://github.com/ethereum/consensus-specs/issues/4740) - 2025-11-12
-* [Pull Request] []() - 2025-11-12
+* [Pull Request] [Set `block_hash` in the latest bid during Gloas state upgrade](https://github.com/ethereum/consensus-specs/pull/4739) - 2025-11-12
 ## Q3 2025
 
 

--- a/members/sudeepdino008.md
+++ b/members/sudeepdino008.md
@@ -33,6 +33,7 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [stage_exec restart is failing consistently because of nonce too low errors](https://github.com/erigontech/erigon/issues/19473) - 2026-02-25
 * [Pull Request] [Cherry-pick #19698: UnitTest for reset page counter on collision in buildVI](https://github.com/erigontech/erigon/pull/19754) - 2026-03-10
 * [Commit] [Cherry-pick #19698: UnitTest for reset page counter on collision in buildVI (#19754)](https://github.com/erigontech/erigon/commit/59bd509cebca45204c223697823472e4c374cef5) - 2026-03-10
+* [Review] [Review on: recsplit: keyPos reset on retry](https://github.com/erigontech/erigon/pull/19773#pullrequestreview-3920376885) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/sudeepdino008.md
+++ b/members/sudeepdino008.md
@@ -13,16 +13,16 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
 * [Issue] [seg backup/mirror command](https://github.com/erigontech/erigon/issues/18571) - 2026-01-06
-* [Pull Request] []() - 2026-01-07
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-15
+* [Pull Request] [refresh cfg cache when knownPreverified is changed](https://github.com/erigontech/erigon/pull/18589) - 2026-01-07
+* [Pull Request] [fix Preverified.Type to consider index version correctly](https://github.com/erigontech/erigon/pull/18607) - 2026-01-09
+* [Pull Request] [remove missed-idx log](https://github.com/erigontech/erigon/pull/18681) - 2026-01-15
 * [Issue] [help output even after execution](https://github.com/erigontech/erigon/issues/18714) - 2026-01-19
-* [Pull Request] []() - 2026-01-19
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [use less expensive signal for BuildMissedIndices](https://github.com/erigontech/erigon/pull/18712) - 2026-01-19
+* [Pull Request] [update version to 3.3.4](https://github.com/erigontech/erigon/pull/18739) - 2026-01-21
 * [Issue] [port collision between torrentClientStatus and pprof (seg integrity)](https://github.com/erigontech/erigon/issues/18778) - 2026-01-23
 * [Issue] [torrent verification and recovery](https://github.com/erigontech/erigon/issues/18776) - 2026-01-23
-* [Pull Request] []() - 2026-01-24
-* [Pull Request] []() - 2026-01-26
+* [Pull Request] [fix for some commitment.kv using more plainkeys than references](https://github.com/erigontech/erigon/pull/18774) - 2026-01-24
+* [Pull Request] [check txnum index existence before commitment rebuild](https://github.com/erigontech/erigon/pull/18805) - 2026-01-26
 * [Issue] [gnosis commitment history generation](https://github.com/erigontech/erigon/issues/18893) - 2026-01-30
 * [Issue] [integrity cache for faster file checks](https://github.com/erigontech/erigon/issues/18890) - 2026-01-30
 * [Issue] [Erigon Publishable v3](https://github.com/erigontech/erigon/issues/18889) - 2026-01-30
@@ -31,6 +31,8 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [tool to regenerate commitment history](https://github.com/erigontech/erigon/issues/18954) - 2026-02-04
 * [Issue] [receipt root checker tool](https://github.com/erigontech/erigon/issues/19421) - 2026-02-23
 * [Issue] [stage_exec restart is failing consistently because of nonce too low errors](https://github.com/erigontech/erigon/issues/19473) - 2026-02-25
+* [Pull Request] [Cherry-pick #19698: UnitTest for reset page counter on collision in buildVI](https://github.com/erigontech/erigon/pull/19754) - 2026-03-10
+* [Commit] [Cherry-pick #19698: UnitTest for reset page counter on collision in buildVI (#19754)](https://github.com/erigontech/erigon/commit/59bd509cebca45204c223697823472e4c374cef5) - 2026-03-10
 ## Q4 2025
 
 
@@ -80,7 +82,7 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [prevent empty .yml creation on Github during release](https://github.com/erigontech/erigon/issues/17844) - 2025-11-10
 * [Issue] [add rpc-test to release process](https://github.com/erigontech/erigon/issues/17843) - 2025-11-10
 * [Issue] [faster integrity for rcache/receipt](https://github.com/erigontech/erigon/issues/17842) - 2025-11-10
-* [Pull Request] []() - 2025-11-11
+* [Pull Request] [caplin files publishable check [v33]](https://github.com/erigontech/erigon/pull/17857) - 2025-11-11
 * [Issue] [snapshotter health check: if erigon is on chaintip or not](https://github.com/erigontech/erigon/issues/17868) - 2025-11-12
 * [Issue] [manage releases better in snapshot automation script](https://github.com/erigontech/erigon/issues/18133) - 2025-12-02
 * [Issue] [torrent file verification doesn't finish](https://github.com/erigontech/erigon/issues/18162) - 2025-12-04
@@ -88,9 +90,9 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [snapshot reset dryrun mode doesn't show any files](https://github.com/erigontech/erigon/issues/18191) - 2025-12-05
 * [Issue] [stage_exec is broken](https://github.com/erigontech/erigon/issues/18227) - 2025-12-09
 * [Issue] [add caplin state snapshots to `seg index` command](https://github.com/erigontech/erigon/issues/18265) - 2025-12-11
-* [Pull Request] []() - 2025-12-18
-* [Pull Request] []() - 2025-12-20
-* [Pull Request] []() - 2025-12-31
+* [Pull Request] [change settings of dir logging](https://github.com/erigontech/erigon/pull/18379) - 2025-12-18
+* [Pull Request] [half block exec fix in receipts](https://github.com/erigontech/erigon/pull/18397) - 2025-12-20
+* [Pull Request] [relax some publishable checks for blobsidecars](https://github.com/erigontech/erigon/pull/18523) - 2025-12-31
 ## Q3 2025
 
 

--- a/members/taratorio.md
+++ b/members/taratorio.md
@@ -12,23 +12,23 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 
 
 [nethermindeth/gas-benchmarks](https://github.com/nethermindeth/gas-benchmarks)
-* [Pull Request] []() - 2026-01-14
+* [Pull Request] [add --rerunSyncing for preparation files](https://github.com/NethermindEth/gas-benchmarks/pull/99) - 2026-01-14
 * [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-19
+* [Pull Request] [add --rerunSyncing for preparation files (#99)](https://github.com/NethermindEth/gas-benchmarks/pull/102) - 2026-01-19
 
-* [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-10
+* [Pull Request] [fix erigon flags for new repricing tests](https://github.com/NethermindEth/gas-benchmarks/pull/107) - 2026-02-05
+* [Pull Request] [fix erigon flags for new repricing tests](https://github.com/NethermindEth/gas-benchmarks/pull/109) - 2026-02-10
 [erigontech/erigon](https://github.com/erigontech/erigon)
-* [Pull Request] []() - 2026-01-20
+* [Pull Request] [execution/stagedsync: update StageLoop func to always pass external tx and sd](https://github.com/erigontech/erigon/pull/18727) - 2026-01-20
 * [Issue] [shutter handle non-matching ordering of decryption keys based on txnindex](https://github.com/erigontech/erigon/issues/18780) - 2026-01-23
 * [Issue] [Flaky TestSendRawTransactionSync](https://github.com/erigontech/erigon/issues/18884) - 2026-01-30
 * [Issue] [receiptHash mismatch in gas-benchmarks for receipts with large amounts of logs](https://github.com/erigontech/erigon/issues/18920) - 2026-02-02
 * [Issue] [add unified slow-block log](https://github.com/erigontech/erigon/issues/19012) - 2026-02-06
 * [Issue] [sporadic could not start execution service due to error snapshot already loaded with different infohash](https://github.com/erigontech/erigon/issues/19128) - 2026-02-12
-* [Pull Request] []() - 2026-02-14
+* [Pull Request] [workflows: add --sim.parallelism to hive runs](https://github.com/erigontech/erigon/pull/19172) - 2026-02-14
 * [Issue] [flaky TestTable_findnodeByID](https://github.com/erigontech/erigon/issues/19158) - 2026-02-13
 * [Issue] [experimental](https://github.com/erigontech/erigon/issues/19451) - 2026-02-24
-* [Pull Request] []() - 2026-03-04
+* [Pull Request] [[DO-NOT-MERGE] execution: implement EIP-8037](https://github.com/erigontech/erigon/pull/19596) - 2026-03-04
 ## Q4 2025
 
 
@@ -47,12 +47,12 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [Fix flaky TestGetProof](https://github.com/erigontech/erigon/issues/17740) - 2025-11-01
 * [Issue] [move referencing/dereferencing logic of commitment outside of DB into app layer](https://github.com/erigontech/erigon/issues/17773) - 2025-11-04
 * [Issue] [Fix flaky windows TestSetupGenesis due to mdmx paging file is too small for this operation to complete](https://github.com/erigontech/erigon/issues/17806) - 2025-11-07
-* [Pull Request] []() - 2025-11-26
+* [Pull Request] [db/integrity: add CheckCommitmentHistVal check](https://github.com/erigontech/erigon/pull/18065) - 2025-11-26
 * [Issue] [shutter lost connections to keypers](https://github.com/erigontech/erigon/issues/18217) - 2025-12-09
 * [Issue] [fix hive devp2p eth suite failures](https://github.com/erigontech/erigon/issues/18285) - 2025-12-12
 
 [ethereum/hive](https://github.com/ethereum/hive)
-* [Pull Request] []() - 2025-12-15
+* [Pull Request] [simulators/ethereum/engine: fix cancun bpo schedule error](https://github.com/ethereum/hive/pull/1377) - 2025-12-15
 * [Pull Request] []() - 2025-12-23
 ## Q3 2025
 

--- a/members/tbenr.md
+++ b/members/tbenr.md
@@ -30,6 +30,8 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Atbenr)
 [Consensys/teku](https://github.com/Consensys/teku)
 * [Pull Request] [protoarray lookup optimization](https://github.com/Consensys/teku/pull/10448) - 2026-03-10
 * [Commit] [protoarray lookup optimization (#10448)](https://github.com/Consensys/teku/commit/616b29a770f098ac412559829d1e3cca42e5f95c) - 2026-03-10
+* [Review] [Review on: Engine api optimizations](https://github.com/Consensys/teku/pull/10469#pullrequestreview-3920771283) - 2026-03-10
+* [Review] [Review on: Engine api optimizations](https://github.com/Consensys/teku/pull/10469#pullrequestreview-3921573699) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/tbenr.md
+++ b/members/tbenr.md
@@ -14,18 +14,22 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Atbenr)
 [consensys/teku](https://github.com/consensys/teku)
 * [Issue] [We should subscribe to data columns subnets when following the chain optimistically](https://github.com/Consensys/teku/issues/10275) - 2026-01-15
 * [Issue] [`engine_forkchoiceUpdatedV4` for BALs](https://github.com/Consensys/teku/issues/10298) - 2026-01-26
-* [Pull Request] []() - 2026-02-08
+* [Pull Request] [optimize single attestation conversion](https://github.com/Consensys/teku/pull/10343) - 2026-02-08
 * [Issue] [fork choice changes](https://github.com/Consensys/teku/issues/10369) - 2026-02-12
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-20
+* [Pull Request] [is_proposer_equivocation check](https://github.com/Consensys/teku/pull/10379) - 2026-02-13
+* [Pull Request] [Reimplement ForkAwareTimeBasedEventAdapter](https://github.com/Consensys/teku/pull/10389) - 2026-02-18
+* [Pull Request] [Progressive ssz](https://github.com/Consensys/teku/pull/10395) - 2026-02-20
 
 * [Issue] [exception on every epoch transition](https://github.com/Consensys/teku/issues/10423) - 2026-02-25
 * [Issue] [Migrate to javalin 7](https://github.com/Consensys/teku/issues/10428) - 2026-02-26
 * [Issue] [Extend by_root reqresp serve range to match by_range](https://github.com/Consensys/teku/issues/10451) - 2026-03-05
 [consensys/discovery](https://github.com/consensys/discovery)
-* [Pull Request] []() - 2026-02-21
+* [Pull Request] [Introduce enr sig cache and bump nodeIdCache cache](https://github.com/Consensys/discovery/pull/197) - 2026-02-21
 * [Pull Request] []() - 2026-02-23
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [protoarray lookup optimization](https://github.com/Consensys/teku/pull/10448) - 2026-03-10
+* [Commit] [protoarray lookup optimization (#10448)](https://github.com/Consensys/teku/commit/616b29a770f098ac412559829d1e3cca42e5f95c) - 2026-03-10
 ## Q4 2025
 
 
@@ -38,19 +42,19 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Atbenr)
 * [Issue] [Long sync after node restart (holesky)](https://github.com/Consensys/teku/issues/9991) - 2025-10-09
 * [Commit] [Always log error exception for block production (#9985)](https://github.com/Consensys/teku/commit/cb16f65ae5b67353f212dc5323055183f18ef7db) - 2025-10-10
 * [Pull Request] [Improved DAS sampler](https://github.com/Consensys/teku/pull/10006) - 2025-10-13
-* [Pull Request] []() - 2025-10-14
+* [Pull Request] [fix latest finalized slot](https://github.com/Consensys/teku/pull/10014) - 2025-10-14
 * [Issue] [Remove FirstSamplerIncompleteSlot DB variable since it is not used](https://github.com/Consensys/teku/issues/10026) - 2025-10-16
 * [Issue] [nodeId and column custody consistency](https://github.com/Consensys/teku/issues/10039) - 2025-10-21
-* [Pull Request] []() - 2025-10-24
+* [Pull Request] [Change docker jdk24 to jdk25](https://github.com/Consensys/teku/pull/10056) - 2025-10-24
 
 * [Issue] [Deactivate DENEB classes when safely in FULU](https://github.com/Consensys/teku/issues/10089) - 2025-10-31
 * [Issue] [Reimplement columnSidecars backfilling](https://github.com/Consensys/teku/issues/10105) - 2025-11-05
-* [Pull Request] []() - 2025-11-05
+* [Pull Request] [Do not try to publish reconstructed columns while syncing](https://github.com/Consensys/teku/pull/10104) - 2025-11-05
 * [Issue] [Reduce noise when `ThrottlingStorageQueryChannel` throws a `QueueIsFullException`](https://github.com/Consensys/teku/issues/10123) - 2025-11-11
-* [Pull Request] []() - 2025-11-21
+* [Pull Request] [Das custody backfiller (DASCustodySync rewrite)](https://github.com/Consensys/teku/pull/10159) - 2025-11-21
 * [Issue] [Sync may stall if SimpleSidecarRetriever's RPC calls fail](https://github.com/Consensys/teku/issues/10185) - 2025-11-28
-* [Pull Request] []() - 2025-12-10
-* [Pull Request] []() - 2025-12-12
+* [Pull Request] [Fix DasPreSampler exception - immutable presampling block list](https://github.com/Consensys/teku/pull/10222) - 2025-12-10
+* [Pull Request] [Allow getBlobs API to retrieve required sidecars on demand](https://github.com/Consensys/teku/pull/10234) - 2025-12-12
 * [Issue] [`DataColumnSidecarPruner` should update EarliestAvailableDataColumnSlot](https://github.com/Consensys/teku/issues/10246) - 2025-12-16
 * [Issue] [`StatusMessageFactory::updateEarliestAvailableSlot` not going earlier than DA window lower bound](https://github.com/Consensys/teku/issues/10245) - 2025-12-16
 * [Issue] [Add an AT for getBlobs api with download feature enabled](https://github.com/Consensys/teku/issues/10252) - 2025-12-18

--- a/members/tcoratger.md
+++ b/members/tcoratger.md
@@ -34,3 +34,6 @@ Github: [@tcoratger](https://github.com/tcoratger)
 * [Pull Request] [poseidon1: speedup monty-31 packed version on avx](https://github.com/Plonky3/Plonky3/pull/1420) - 2026-03-10
 * [Pull Request] [monty 31: faster forward dft](https://github.com/Plonky3/Plonky3/pull/1418) - 2026-03-10
 * [Commit] [monty 31: faster forward dft (#1418)](https://github.com/Plonky3/Plonky3/commit/14fd70b73857d17977d17a952371d77b38c39261) - 2026-03-10
+* [Review] [Review on: chore: release v0.5.0](https://github.com/Plonky3/Plonky3/pull/1426#pullrequestreview-3922977898) - 2026-03-10
+* [Review] [Review on: monty 31: faster forward dft](https://github.com/Plonky3/Plonky3/pull/1418#pullrequestreview-3922076936) - 2026-03-10
+* [Review] [Review on: monty 31: faster forward dft](https://github.com/Plonky3/Plonky3/pull/1418#pullrequestreview-3922077726) - 2026-03-10

--- a/members/tcoratger.md
+++ b/members/tcoratger.md
@@ -10,20 +10,27 @@ Github: [@tcoratger](https://github.com/tcoratger)
 
 
 [plonky3/plonky3](https://github.com/plonky3/plonky3)
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-05
+* [Pull Request] [field: implement quintic extension for KoalaBear](https://github.com/Plonky3/Plonky3/pull/1293) - 2026-02-03
+* [Pull Request] [field: faster `quintic_mul` and `quintic_square`](https://github.com/Plonky3/Plonky3/pull/1301) - 2026-02-05
 * [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-22
-* [Pull Request] []() - 2026-02-23
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [rand: small import fix](https://github.com/Plonky3/Plonky3/pull/1316) - 2026-02-09
+* [Pull Request] [air: add `num_constraints` and `AirBuilderWithContext`](https://github.com/Plonky3/Plonky3/pull/1327) - 2026-02-22
+* [Pull Request] [util: faster rectangular transposition 64-bit fields](https://github.com/Plonky3/Plonky3/pull/1332) - 2026-02-23
+* [Pull Request] [air: more granularity for next row](https://github.com/Plonky3/Plonky3/pull/1340) - 2026-02-25
 * [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-02-28
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-03
-* [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-05
-* [Pull Request] []() - 2026-03-06
+* [Pull Request] [matrix: add height field](https://github.com/Plonky3/Plonky3/pull/1355) - 2026-02-27
+* [Pull Request] [feat: support for 4-to-1 Poseidon2 instantiations for 32-bit fields](https://github.com/Plonky3/Plonky3/pull/1359) - 2026-02-28
+* [Pull Request] [air: more complete symbolic test suite and adjustments](https://github.com/Plonky3/Plonky3/pull/1375) - 2026-03-02
+* [Pull Request] [poseidon1: add arithmetization crate](https://github.com/Plonky3/Plonky3/pull/1384) - 2026-03-03
+* [Pull Request] [air: some touchups for `ConstraintLayout` and tests](https://github.com/Plonky3/Plonky3/pull/1393) - 2026-03-04
+* [Pull Request] [poseidon1: add aarch64 neon packing strategy for Goldilocks](https://github.com/Plonky3/Plonky3/pull/1401) - 2026-03-05
+* [Pull Request] [field: add packing strategy for `mixed_dot_product`](https://github.com/Plonky3/Plonky3/pull/1404) - 2026-03-06
 * [Pull Request] []() - 2026-03-08
-* [Pull Request] []() - 2026-03-10
+* [Pull Request] [mersenne31: add poseidon1](https://github.com/Plonky3/Plonky3/pull/1428) - 2026-03-10
+[Plonky3/Plonky3](https://github.com/Plonky3/Plonky3)
+* [Pull Request] [monty31: faster aarch64 neon `octic_mul_packed`](https://github.com/Plonky3/Plonky3/pull/1423) - 2026-03-10
+* [Pull Request] [monty31: faster aarch64 neon `quintic_mul_packed`](https://github.com/Plonky3/Plonky3/pull/1422) - 2026-03-10
+* [Pull Request] [field: add missing extension degree for `packed_mod_add` and `packed_mod_sub`](https://github.com/Plonky3/Plonky3/pull/1421) - 2026-03-10
+* [Pull Request] [poseidon1: speedup monty-31 packed version on avx](https://github.com/Plonky3/Plonky3/pull/1420) - 2026-03-10
+* [Pull Request] [monty 31: faster forward dft](https://github.com/Plonky3/Plonky3/pull/1418) - 2026-03-10
+* [Commit] [monty 31: faster forward dft (#1418)](https://github.com/Plonky3/Plonky3/commit/14fd70b73857d17977d17a952371d77b38c39261) - 2026-03-10

--- a/members/terencechain.md
+++ b/members/terencechain.md
@@ -12,24 +12,30 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Aterencecha
 
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2026-01-27
-* [Pull Request] []() - 2026-01-31
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-11
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-17
+* [Pull Request] [gloas: sample PTC per committee](https://github.com/OffchainLabs/prysm/pull/16293) - 2026-01-27
+* [Pull Request] [gloas: move kzg commitments to bid](https://github.com/OffchainLabs/prysm/pull/16309) - 2026-01-31
+* [Pull Request] [Run go fmt](https://github.com/OffchainLabs/prysm/pull/16311) - 2026-02-02
+* [Pull Request] [Add gossip for payload attestation](https://github.com/OffchainLabs/prysm/pull/16333) - 2026-02-06
+* [Pull Request] [gloas: add read only wrapper for payload envelope](https://github.com/OffchainLabs/prysm/pull/16339) - 2026-02-07
+* [Pull Request] [gloas: add modified attestation processing](https://github.com/OffchainLabs/prysm/pull/15736) - 2026-02-11
+* [Pull Request] [Add Gloas attestation committee index validation](https://github.com/OffchainLabs/prysm/pull/16359) - 2026-02-13
+* [Pull Request] [Edit to validator self build for gloas](https://github.com/OffchainLabs/prysm/pull/16366) - 2026-02-17
 
-* [Pull Request] []() - 2026-02-20
-* [Pull Request] []() - 2026-02-22
-* [Pull Request] []() - 2026-02-25
-* [Pull Request] []() - 2026-02-27
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-06
-* [Pull Request] []() - 2026-03-08
+* [Pull Request] [Implement upgrade gloas](https://github.com/OffchainLabs/prysm/pull/16378) - 2026-02-20
+* [Pull Request] [Gloas Devnet 0](https://github.com/OffchainLabs/prysm/pull/16381) - 2026-02-22
+* [Pull Request] [Fix Gloas builders sweep when builders list is empty](https://github.com/OffchainLabs/prysm/pull/16411) - 2026-02-25
+* [Pull Request] [Use gloas state latest block hash for FCU head hash](https://github.com/OffchainLabs/prysm/pull/16438) - 2026-02-27
+* [Pull Request] [Fix Gloas fork version using `MetaDataV1` instead of `MetaDataV2`](https://github.com/OffchainLabs/prysm/pull/16448) - 2026-03-02
+* [Pull Request] [duties: wire PTC slot assignments into validator duty pipeline](https://github.com/OffchainLabs/prysm/pull/16489) - 2026-03-06
+* [Pull Request] [proposer: use correct access root to get pre state](https://github.com/OffchainLabs/prysm/pull/16496) - 2026-03-08
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
-* [Pull Request] []() - 2026-02-18
+* [Pull Request] [Request missing payload envelopes for index-1 attestation](https://github.com/ethereum/consensus-specs/pull/4939) - 2026-02-18
+
+[OffchainLabs/prysm](https://github.com/OffchainLabs/prysm)
+* [Pull Request] [fix: guard against fork boundary `IsParentBlockFull` false positive](https://github.com/OffchainLabs/prysm/pull/16510) - 2026-03-10
+* [Pull Request] [forkchoice: fix head change on every attestation tick pre gloas](https://github.com/OffchainLabs/prysm/pull/16508) - 2026-03-10
+* [Pull Request] [proposer: add payload attestations packing](https://github.com/OffchainLabs/prysm/pull/16493) - 2026-03-10
+* [Commit] [proposer: add payload attestations packing (#16493)](https://github.com/OffchainLabs/prysm/commit/4da5ed072c29f7ee86e3014fc091d4f33e5a8ec2) - 2026-03-10
 ## Q4 2025
 
 
@@ -46,15 +52,15 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Aterencecha
 * [Commit] [exclude unscheduled forks from the schedule (#15799)](https://github.com/OffchainLabs/prysm/commit/74c47e25a919ee5847de9637964ece93db939ba8) - 2025-10-08
 * [Commit] [Change wording](https://github.com/OffchainLabs/prysm/commit/6d62267ccb97ca213939c4bfe76c9d324080c4cd) - 2025-10-13
 * [Commit] [Fix ignored gossip attestation validation for early arriving attestations (#15840)](https://github.com/OffchainLabs/prysm/commit/0aa248e6631912142690929984ac924f31c08ae1) - 2025-10-13
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-10-26
+* [Pull Request] [Return optimistic response only when handling blinded blocks](https://github.com/OffchainLabs/prysm/pull/15925) - 2025-10-23
+* [Pull Request] [Fix timer leak in data column peer selection](https://github.com/OffchainLabs/prysm/pull/15932) - 2025-10-26
 
 [offchainlabs/prysm](https://github.com/offchainlabs/prysm)
-* [Pull Request] []() - 2025-11-01
-* [Pull Request] []() - 2025-11-16
-* [Pull Request] []() - 2025-12-04
-* [Pull Request] []() - 2025-12-14
-* [Pull Request] []() - 2025-12-20
+* [Pull Request] [Update spec test to v1.6.0-beta.2](https://github.com/OffchainLabs/prysm/pull/15960) - 2025-11-01
+* [Pull Request] [Always fire payload attribute events when attributes exist](https://github.com/OffchainLabs/prysm/pull/16023) - 2025-11-16
+* [Pull Request] [Add arrival latency tracking for data column sidecars](https://github.com/OffchainLabs/prysm/pull/16099) - 2025-12-04
+* [Pull Request] [Guard KZG send with context cancellation](https://github.com/OffchainLabs/prysm/pull/16144) - 2025-12-14
+* [Pull Request] [feat(primitives): add BuilderIndex SSZ type](https://github.com/OffchainLabs/prysm/pull/16169) - 2025-12-20
 ## Q3 2025
 
 

--- a/members/terencechain.md
+++ b/members/terencechain.md
@@ -36,6 +36,13 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Aterencecha
 * [Pull Request] [forkchoice: fix head change on every attestation tick pre gloas](https://github.com/OffchainLabs/prysm/pull/16508) - 2026-03-10
 * [Pull Request] [proposer: add payload attestations packing](https://github.com/OffchainLabs/prysm/pull/16493) - 2026-03-10
 * [Commit] [proposer: add payload attestations packing (#16493)](https://github.com/OffchainLabs/prysm/commit/4da5ed072c29f7ee86e3014fc091d4f33e5a8ec2) - 2026-03-10
+* [Review] [Review on: adding payload_attestation_message event](https://github.com/OffchainLabs/prysm/pull/16506#pullrequestreview-3923779374) - 2026-03-10
+* [Review] [Review on: adding payload_attestation_message event](https://github.com/OffchainLabs/prysm/pull/16506#pullrequestreview-3924469538) - 2026-03-10
+* [Review] [Review on: Use execution block hash as state access key post-Gloas](https://github.com/OffchainLabs/prysm/pull/16459#pullrequestreview-3923450265) - 2026-03-10
+* [Review] [Review on: Use execution block hash as state access key post-Gloas](https://github.com/OffchainLabs/prysm/pull/16459#pullrequestreview-3923881825) - 2026-03-10
+* [Review] [Review on: Use execution block hash as state access key post-Gloas](https://github.com/OffchainLabs/prysm/pull/16459#pullrequestreview-3923992219) - 2026-03-10
+* [Review] [Review on: Handle missing Payloads](https://github.com/OffchainLabs/prysm/pull/16460#pullrequestreview-3919309162) - 2026-03-10
+* [Review] [Review on: Fix nil deref introduced with ePBS](https://github.com/OffchainLabs/prysm/pull/16450#pullrequestreview-3922637390) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/terencechain.md
+++ b/members/terencechain.md
@@ -28,6 +28,7 @@ Team: [Prysm](https://github.com/Prysmaticlabs/Prysm/pulls?q=author%3Aterencecha
 * [Pull Request] []() - 2026-03-02
 * [Pull Request] []() - 2026-03-06
 * [Pull Request] []() - 2026-03-08
+* [Pull Request] []() - 2026-03-10
 [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs)
 * [Pull Request] []() - 2026-02-18
 ## Q4 2025

--- a/members/tersec.md
+++ b/members/tersec.md
@@ -25,15 +25,15 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Issue] [Update EIP-7928 to cap max items](https://github.com/status-im/nimbus-eth1/issues/3985) - 2026-02-16
 * [Issue] [Implement EIP-8037](https://github.com/status-im/nimbus-eth1/issues/3984) - 2026-02-16
 * [Issue] [Implement EIP-7954](https://github.com/status-im/nimbus-eth1/issues/3983) - 2026-02-16
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [update to Nim v2.2.8](https://github.com/status-im/nimbus-eth1/pull/4006) - 2026-02-23
 [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2)
-* [Pull Request] []() - 2026-02-10
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-14
-* [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-21
-* [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-02
+* [Pull Request] [bump nim-ssz-serialization to 7846bd523f135b9d94954fd084105bcd7f3755b2](https://github.com/status-im/nimbus-eth2/pull/7951) - 2026-02-10
+* [Pull Request] [fix 32-bit compilation errors in fork choice](https://github.com/status-im/nimbus-eth2/pull/7974) - 2026-02-13
+* [Pull Request] [don't assume gh-pages branch exists locally in publish-book Makefile target](https://github.com/status-im/nimbus-eth2/pull/7977) - 2026-02-14
+* [Pull Request] [Revert "Revert "chronos: v4.2.0""](https://github.com/status-im/nimbus-eth2/pull/8000) - 2026-02-18
+* [Pull Request] [remove obsolete NUMBER_OF_COLUMNS runtime config](https://github.com/status-im/nimbus-eth2/pull/8005) - 2026-02-21
+* [Pull Request] [bump nim-lsquic to 86b8efc703d06a493fa984b76e4ffb6ddde99c41](https://github.com/status-im/nimbus-eth2/pull/8037) - 2026-02-26
+* [Pull Request] [rm some unused parameters and imports](https://github.com/status-im/nimbus-eth2/pull/8049) - 2026-03-02
 ## Q4 2025
 
 
@@ -83,10 +83,10 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Commit] [fix attempting to call undeclared routine: 'allIt' (#7585)](https://github.com/status-im/nimbus-eth2/commit/0d7c33a479007559d87623e9c14a0f9af3ccf3fe) - 2025-10-10
 * [Commit] [rm unused attestation pool phase0 aggregation code (#7600)](https://github.com/status-im/nimbus-eth2/commit/3e88143fb541d896a189da69f5773b664057943e) - 2025-10-11
 * [Commit] [drop vcus backfilling and adjust eas movement (#7601)](https://github.com/status-im/nimbus-eth2/commit/eecd55dd2df6779e37fffffc3061f33502464aca) - 2025-10-12
-* [Pull Request] []() - 2025-11-06
-* [Pull Request] []() - 2025-11-15
-* [Pull Request] []() - 2025-11-18
-* [Pull Request] []() - 2025-12-02
+* [Pull Request] [Revert "swich to Nim v2.2.6"](https://github.com/status-im/nimbus-eth2/pull/7719) - 2025-11-06
+* [Pull Request] [rm Electra builder API support](https://github.com/status-im/nimbus-eth2/pull/7733) - 2025-11-15
+* [Pull Request] [work around blob quarantine infinite loop](https://github.com/status-im/nimbus-eth2/pull/7742) - 2025-11-18
+* [Pull Request] [enforce via taskpools that refc objects don't cross thread heaps](https://github.com/status-im/nimbus-eth2/pull/7773) - 2025-12-02
 [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1)
 * [Commit] [proxy: refactor (#3709)](https://github.com/status-im/nimbus-eth1/commit/cacde70cbe18ab34b70d0470701bcf0587171071) - 2025-10-06
 * [Commit] [Fix OverflowDefect crash in block validation (#3741)](https://github.com/status-im/nimbus-eth1/commit/f5eebe4d02e5647eead49e2ce855e89c94e3e31c) - 2025-10-06
@@ -94,7 +94,7 @@ Team: [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2/pulls?q=a
 * [Issue] [Schedule Osaka mainnet fork](https://github.com/status-im/nimbus-eth1/issues/3804) - 2025-11-01
 
 [ethereum/pm](https://github.com/ethereum/pm)
-* [Pull Request] []() - 2025-12-01
+* [Pull Request] [fix Nimbus Fusaka contact information](https://github.com/ethereum/pm/pull/1827) - 2025-12-01
 
 [nethermindeth/nethermind](https://github.com/nethermindeth/nethermind)
 * [Issue] [Fake `INVALID` on mainnet slot 13164552](https://github.com/NethermindEth/nethermind/issues/9878) - 2025-12-04

--- a/members/tumas.md
+++ b/members/tumas.md
@@ -12,22 +12,22 @@ Team: Grandine
 
 
 [grandinetech/grandine](https://github.com/grandinetech/grandine)
-* [Pull Request] []() - 2026-01-08
-* [Pull Request] []() - 2026-01-21
+* [Pull Request] [Update peerdas metrics](https://github.com/grandinetech/grandine/pull/565) - 2026-01-08
+* [Pull Request] [Add `--supernode` and `--semi-supernode` command line options](https://github.com/grandinetech/grandine/pull/573) - 2026-01-21
 * [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-02
-* [Pull Request] []() - 2026-02-06
-* [Pull Request] []() - 2026-02-09
+* [Pull Request] [Use client versions in builder blocks](https://github.com/grandinetech/grandine/pull/580) - 2026-01-29
+* [Pull Request] [Add Grandine version to metrics](https://github.com/grandinetech/grandine/pull/586) - 2026-02-02
+* [Pull Request] [Update eth2_libp2p](https://github.com/grandinetech/grandine/pull/595) - 2026-02-06
+* [Pull Request] [Add tracing instrumentation to Beacon API](https://github.com/grandinetech/grandine/pull/598) - 2026-02-09
 * [Pull Request] []() - 2026-02-17
 * [Pull Request] []() - 2026-02-18
-* [Pull Request] []() - 2026-02-24
-* [Pull Request] []() - 2026-02-25
+* [Pull Request] [Store checkpoint state during syncing every archival epoch interval](https://github.com/grandinetech/grandine/pull/609) - 2026-02-24
+* [Pull Request] [Fix sync start issue when head is considered 'forward_synced'](https://github.com/grandinetech/grandine/pull/610) - 2026-02-25
 * [Pull Request] []() - 2026-02-26
-* [Pull Request] []() - 2026-03-02
-* [Pull Request] []() - 2026-03-03
+* [Pull Request] [Add `--data-availability-window` CLI argument](https://github.com/grandinetech/grandine/pull/628) - 2026-03-02
+* [Pull Request] [Upgrade crates and replace `bincode` with `wincode` & bump Rust version](https://github.com/grandinetech/grandine/pull/630) - 2026-03-03
 * [Pull Request] []() - 2026-03-04
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [Update dependencies](https://github.com/grandinetech/grandine/pull/632) - 2026-03-09
 ## Q4 2025
 
 
@@ -37,21 +37,21 @@ Team: Grandine
 * [Pull Request] [Fix typos](https://github.com/grandinetech/grandine/pull/414) - 2025-10-09
 * [Pull Request] [Check data availability ranges in range requests](https://github.com/grandinetech/grandine/pull/413) - 2025-10-09
 * [Commit] [Take into account `earliest_available_slot` when build sync batches](https://github.com/grandinetech/grandine/commit/4db1043b56facfb0992496e8a500e5b65edff225) - 2025-10-13
-* [Pull Request] []() - 2025-10-14
-* [Pull Request] []() - 2025-10-22
-* [Pull Request] []() - 2025-10-23
-* [Pull Request] []() - 2025-10-24
-* [Pull Request] []() - 2025-10-28
-* [Pull Request] []() - 2025-11-07
-* [Pull Request] []() - 2025-11-18
-* [Pull Request] []() - 2025-11-21
-* [Pull Request] []() - 2025-11-24
-* [Pull Request] []() - 2025-11-28
-* [Pull Request] []() - 2025-12-08
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-12
-* [Pull Request] []() - 2025-12-18
-* [Pull Request] []() - 2025-12-21
+* [Pull Request] [Import blocks if 50% columns accepted](https://github.com/grandinetech/grandine/pull/424) - 2025-10-14
+* [Pull Request] [Don't use `RUST_LOG` when setting up logging filters](https://github.com/grandinetech/grandine/pull/440) - 2025-10-22
+* [Pull Request] [Don't error on ignore result when publishing via beacon API](https://github.com/grandinetech/grandine/pull/442) - 2025-10-23
+* [Pull Request] [Enforce stricter `verify_kzg_proofs` result checks](https://github.com/grandinetech/grandine/pull/445) - 2025-10-24
+* [Pull Request] [Update Rust to 1.90.0](https://github.com/grandinetech/grandine/pull/448) - 2025-10-28
+* [Pull Request] [Update Rust edition to 2024](https://github.com/grandinetech/grandine/pull/471) - 2025-11-07
+* [Pull Request] [Export telemetry metrics to the specified gRPC collector](https://github.com/grandinetech/grandine/pull/487) - 2025-11-18
+* [Pull Request] [Reduce block root computations](https://github.com/grandinetech/grandine/pull/492) - 2025-11-21
+* [Pull Request] [Add `--disable-http-api` CLI argument](https://github.com/grandinetech/grandine/pull/497) - 2025-11-24
+* [Pull Request] [Tracing fixes](https://github.com/grandinetech/grandine/pull/501) - 2025-11-28
+* [Pull Request] [Spawn state cache pruning task from `Mutator` instead of locking within `Store`](https://github.com/grandinetech/grandine/pull/522) - 2025-12-08
+* [Pull Request] [Return `PhaseError` on block/state phase mismatch when processing blocks](https://github.com/grandinetech/grandine/pull/533) - 2025-12-11
+* [Pull Request] [Add missing values to `Config` (#534)](https://github.com/grandinetech/grandine/pull/535) - 2025-12-12
+* [Pull Request] [Offload back sync batch validation to a low-priority dedicated executor](https://github.com/grandinetech/grandine/pull/542) - 2025-12-18
+* [Pull Request] [Revert "Reduce block root computations"](https://github.com/grandinetech/grandine/pull/544) - 2025-12-21
 ## Q3 2025
 
 

--- a/members/twoeths.md
+++ b/members/twoeths.md
@@ -23,6 +23,8 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Pull Request] []() - 2026-02-24
 * [Issue] [Memory leak on network thread](https://github.com/ChainSafe/lodestar/issues/8969) - 2026-03-02
 * [Pull Request] []() - 2026-03-09
+* [Issue] [[gloas] fork-choice compute_head performance issue](https://github.com/ChainSafe/lodestar/issues/9014) - 2026-03-10
+* [Issue] [[gloas] computePayloadTimelinessCommitteesForEpoch performance issue](https://github.com/ChainSafe/lodestar/issues/9013) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/twoeths.md
+++ b/members/twoeths.md
@@ -13,16 +13,25 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
 * [Issue] [Avoid calling BeaconState.clone() in beacon-node](https://github.com/ChainSafe/lodestar/issues/8725) - 2026-01-05
-* [Pull Request] []() - 2026-01-06
+* [Pull Request] [refactor: move reward apis to state-transition](https://github.com/ChainSafe/lodestar/pull/8719) - 2026-01-06
 * [Issue] [State repositories to work with Uint8Array instead of BeaconStateAllForks](https://github.com/ChainSafe/lodestar/issues/8729) - 2026-01-08
-* [Pull Request] []() - 2026-01-09
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-26
+* [Pull Request] [refactor: generalize state repositories](https://github.com/ChainSafe/lodestar/pull/8732) - 2026-01-09
+* [Pull Request] [refactor: simplify get proposer's SignatureSet](https://github.com/ChainSafe/lodestar/pull/8745) - 2026-01-16
+* [Pull Request] [chore: skip Map benchmarks](https://github.com/ChainSafe/lodestar/pull/8787) - 2026-01-26
 * [Issue] [Performance issue archiving DataColumnSidecars](https://github.com/ChainSafe/lodestar/issues/8794) - 2026-01-28
-* [Pull Request] []() - 2026-02-04
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [chore: model pre-gloas block index as number](https://github.com/ChainSafe/lodestar/pull/8858) - 2026-02-04
+* [Pull Request] [refactor(fork-choice): simplify maybeUpdateBestChildAndDescendant Gloas edge case](https://github.com/ChainSafe/lodestar/pull/8951) - 2026-02-24
 * [Issue] [Memory leak on network thread](https://github.com/ChainSafe/lodestar/issues/8969) - 2026-03-02
-* [Pull Request] []() - 2026-03-09
+* [Pull Request] [fix: enhance epochIndex to track payloadPresent variants](https://github.com/ChainSafe/lodestar/pull/9006) - 2026-03-09
+
+[ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
+* [Pull Request] [chore: remove getComputeShuffledIndexFn()](https://github.com/ChainSafe/lodestar/pull/9011) - 2026-03-10
+* [Pull Request] [perf: optimize PTC committee computation to avoid per-slot allocations](https://github.com/ChainSafe/lodestar/pull/9012) - 2026-03-10
+* [Issue] [[gloas] computePayloadTimelinessCommitteesForEpoch performance issue](https://github.com/ChainSafe/lodestar/issues/9013) - 2026-03-10
+* [Issue] [[gloas] fork-choice compute_head performance issue](https://github.com/ChainSafe/lodestar/issues/9014) - 2026-03-10
+
+[ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z)
+* [Pull Request] [feat: model phase0 Validator as struct](https://github.com/ChainSafe/lodestar-z/pull/232) - 2026-03-10
 ## Q4 2025
 
 
@@ -35,12 +44,12 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Issue] [[bun] performance issue with forkchoice updateHead() api](https://github.com/ChainSafe/lodestar/issues/8519) - 2025-10-10
 * [Issue] [[bun] beacon-node crashed with subscribe-all-subnet flag](https://github.com/ChainSafe/lodestar/issues/8518) - 2025-10-10
 * [Issue] [[bun] asyncAggregateWithRandomness performance issue](https://github.com/ChainSafe/lodestar/issues/8524) - 2025-10-13
-* [Pull Request] []() - 2025-10-15
-* [Pull Request] []() - 2025-10-16
-* [Pull Request] []() - 2025-10-28
+* [Pull Request] [chore: track computeDeltas() metrics on Grafana](https://github.com/ChainSafe/lodestar/pull/8539) - 2025-10-15
+* [Pull Request] [chore: more logs for maybeArchiveState()](https://github.com/ChainSafe/lodestar/pull/8541) - 2025-10-16
+* [Pull Request] [chore: new BeaconChain dashboard](https://github.com/ChainSafe/lodestar/pull/8581) - 2025-10-28
 * [Issue] [Persist fork_choice on stop and load on restart](https://github.com/ChainSafe/lodestar/issues/8592) - 2025-10-31
 * [Issue] [Improve processAttestations time](https://github.com/ChainSafe/lodestar/issues/8621) - 2025-11-20
-* [Pull Request] []() - 2025-11-20
+* [Pull Request] [fix: verify proposer signatures once per slot](https://github.com/ChainSafe/lodestar/pull/8620) - 2025-11-20
 * [Issue] [fulu: block import increased since fulu](https://github.com/ChainSafe/lodestar/issues/8619) - 2025-11-20
 * [Issue] [Duplicate getIndexedAttestation() during verifying/importing blocks](https://github.com/ChainSafe/lodestar/issues/8625) - 2025-11-21
 * [Issue] [[fulu] writeBlockInputToDb performance issue](https://github.com/ChainSafe/lodestar/issues/8624) - 2025-11-21
@@ -55,13 +64,13 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Issue] [Avoid accessing config, pubkey2index, index2pubkey from cached state](https://github.com/ChainSafe/lodestar/issues/8652) - 2025-12-02
 * [Issue] [Avoid accessing full beacon state in PrepareNextSlotScheduler](https://github.com/ChainSafe/lodestar/issues/8651) - 2025-12-02
 * [Issue] [Decouple beacon-node and state-transition](https://github.com/ChainSafe/lodestar/issues/8650) - 2025-12-02
-* [Pull Request] []() - 2025-12-11
-* [Pull Request] []() - 2025-12-12
+* [Pull Request] [chore: use index2pubkey of BeaconChain](https://github.com/ChainSafe/lodestar/pull/8674) - 2025-12-11
+* [Pull Request] [chore: use pubkey2index from BeaconChain](https://github.com/ChainSafe/lodestar/pull/8691) - 2025-12-12
 * [Issue] [Refactor rewards api to prepare for lodestar-z integration](https://github.com/ChainSafe/lodestar/issues/8690) - 2025-12-12
-* [Pull Request] []() - 2025-12-16
+* [Pull Request] [feat: transfer pending gossipsub message msg data](https://github.com/ChainSafe/lodestar/pull/8689) - 2025-12-16
 * [Issue] [Decouple lodestar and @chainsafe/blst](https://github.com/ChainSafe/lodestar/issues/8695) - 2025-12-16
 * [Issue] [Simplify closestJustifiedBalancesStateToCheckpoint](https://github.com/ChainSafe/lodestar/issues/8717) - 2025-12-26
-* [Pull Request] []() - 2025-12-29
+* [Pull Request] [fix: simplify getBlockSignatureSets api](https://github.com/ChainSafe/lodestar/pull/8720) - 2025-12-29
 ## Q3 2025
 
 

--- a/members/twoeths.md
+++ b/members/twoeths.md
@@ -30,6 +30,8 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Issue] [[gloas] computePayloadTimelinessCommitteesForEpoch performance issue](https://github.com/ChainSafe/lodestar/issues/9013) - 2026-03-10
 * [Issue] [[gloas] fork-choice compute_head performance issue](https://github.com/ChainSafe/lodestar/issues/9014) - 2026-03-10
 
+* [Review] [Review on: fix:  prune serialized cache by block input keys](https://github.com/ChainSafe/lodestar/pull/9007#pullrequestreview-3919170310) - 2026-03-10
+* [Review] [Review on: fix:  prune serialized cache by block input keys](https://github.com/ChainSafe/lodestar/pull/9007#pullrequestreview-3919173106) - 2026-03-10
 [ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z)
 * [Pull Request] [feat: model phase0 Validator as struct](https://github.com/ChainSafe/lodestar-z/pull/232) - 2026-03-10
 ## Q4 2025

--- a/members/weiihann.md
+++ b/members/weiihann.md
@@ -6,3 +6,8 @@ Github: [@weiihann](https://github.com/weiihann)
 
 ## Contributions
 
+## Q1 2026
+
+
+[ethereum/eips](https://github.com/ethereum/eips)
+* [Pull Request] [Add EIP: Tiered State Write Pricing](https://github.com/ethereum/EIPs/pull/11390) - 2026-03-10

--- a/members/wemeetagain.md
+++ b/members/wemeetagain.md
@@ -13,24 +13,27 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 [chainsafe/lodestar](https://github.com/chainsafe/lodestar)
 * [Issue] [Track data archival during sync](https://github.com/ChainSafe/lodestar/issues/8793) - 2026-01-27
-* [Pull Request] []() - 2026-01-29
+* [Pull Request] [chore: reorganize IBeaconStateView interface](https://github.com/ChainSafe/lodestar/pull/8810) - 2026-01-29
 * [Issue] [Refactor signature sets to use indices](https://github.com/ChainSafe/lodestar/issues/8801) - 2026-01-28
-* [Pull Request] []() - 2026-02-03
+* [Pull Request] [feat: allow block import after NUMBER_OF_COLUMNS / 2](https://github.com/ChainSafe/lodestar/pull/8818) - 2026-02-03
 * [Issue] [Drop support for node 22](https://github.com/ChainSafe/lodestar/issues/8867) - 2026-02-05
 * [Pull Request] []() - 2026-02-05
-* [Pull Request] []() - 2026-02-07
-* [Pull Request] []() - 2026-02-09
-* [Pull Request] []() - 2026-02-11
+* [Pull Request] [feat: upgrade to libp2p v3](https://github.com/ChainSafe/lodestar/pull/8880) - 2026-02-07
+* [Pull Request] [chore: more unfinalized block writes panels in dashboard](https://github.com/ChainSafe/lodestar/pull/8884) - 2026-02-09
+* [Pull Request] [test: add unit tests for importBlock](https://github.com/ChainSafe/lodestar/pull/8898) - 2026-02-11
 * [Issue] [Remove light client and prover packages](https://github.com/ChainSafe/lodestar/issues/8892) - 2026-02-11
 
-* [Pull Request] []() - 2026-02-14
-* [Pull Request] []() - 2026-02-16
-* [Pull Request] []() - 2026-02-24
+* [Pull Request] [fix: remove leaked process listener in metrics close()](https://github.com/ChainSafe/lodestar/pull/8894) - 2026-02-14
+* [Pull Request] [test: unskip and fix unknownBlock.test.ts](https://github.com/ChainSafe/lodestar/pull/8897) - 2026-02-16
+* [Pull Request] [chore: properly await async monitoring requests during shutdown](https://github.com/ChainSafe/lodestar/pull/8896) - 2026-02-24
 [chainsafe/lodestar-z](https://github.com/chainsafe/lodestar-z)
-* [Pull Request] []() - 2026-02-12
+* [Pull Request] [feat: add napi bindings](https://github.com/ChainSafe/lodestar-z/pull/173) - 2026-02-12
 * [Issue] [bindings: revisit configuration setting logic](https://github.com/ChainSafe/lodestar-z/issues/215) - 2026-02-12
-* [Pull Request] []() - 2026-02-13
-* [Pull Request] []() - 2026-02-23
+* [Pull Request] [fix: epoch cache shallow clone](https://github.com/ChainSafe/lodestar-z/pull/217) - 2026-02-13
+* [Pull Request] [feat: bls batch ops](https://github.com/ChainSafe/lodestar-z/pull/219) - 2026-02-23
+
+[ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
+* [Pull Request] [refactor: use bitmask instead of Set<boolean> for epochIndex payload tracking](https://github.com/ChainSafe/lodestar/pull/9019) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/wemeetagain.md
+++ b/members/wemeetagain.md
@@ -34,6 +34,9 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 
 [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar)
 * [Pull Request] [refactor: use bitmask instead of Set<boolean> for epochIndex payload tracking](https://github.com/ChainSafe/lodestar/pull/9019) - 2026-03-10
+* [Review] [Review on: chore: fix private imports](https://github.com/ChainSafe/lodestar/pull/8990#pullrequestreview-3923087711) - 2026-03-10
+* [Review] [Review on: chore: pin github actions by commit hash](https://github.com/ChainSafe/lodestar/pull/9017#pullrequestreview-3922646576) - 2026-03-10
+* [Review] [Review on: fix: enhance epochIndex to track payloadPresent variants](https://github.com/ChainSafe/lodestar/pull/9006#pullrequestreview-3922448654) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/wemeetagain.md
+++ b/members/wemeetagain.md
@@ -26,6 +26,7 @@ Team: [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%
 * [Pull Request] []() - 2026-02-14
 * [Pull Request] []() - 2026-02-16
 * [Pull Request] []() - 2026-02-24
+* [Pull Request] []() - 2026-03-10
 [chainsafe/lodestar-z](https://github.com/chainsafe/lodestar-z)
 * [Pull Request] []() - 2026-02-12
 * [Issue] [bindings: revisit configuration setting logic](https://github.com/ChainSafe/lodestar-z/issues/215) - 2026-02-12

--- a/members/yperbasis.md
+++ b/members/yperbasis.md
@@ -33,6 +33,16 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Pull Request] [vm: fix CREATE/CREATE2 collision with EIP-7702 delegated accounts](https://github.com/erigontech/erigon/pull/19777) - 2026-03-10
 * [Pull Request] [txpool: penalize peers sending malformed p2p messages](https://github.com/erigontech/erigon/pull/19781) - 2026-03-10
 * [Commit] [txpool: penalize peers sending malformed p2p messages (#19781)](https://github.com/erigontech/erigon/commit/965cf96a748dc3e3bcd70c2e38a9b47ce64495ac) - 2026-03-10
+* [Review] [Review on: state, stagedsync: IBS 2-cache refactor phase 2+3 — replace StateUpdates with VersionedWrites](https://github.com/erigontech/erigon/pull/19711#pullrequestreview-3920976376) - 2026-03-10
+* [Review] [Review on: state, stagedsync: IBS 2-cache refactor phase 2+3 — replace StateUpdates with VersionedWrites](https://github.com/erigontech/erigon/pull/19711#pullrequestreview-3923037868) - 2026-03-10
+* [Review] [Review on: execution/state: fix WriteAccountStorage skip using stale blockOriginStorage](https://github.com/erigontech/erigon/pull/19748#pullrequestreview-3921038464) - 2026-03-10
+* [Review] [Review on: [SharovBot] ci: enable Docker layer caching for Hive workflows](https://github.com/erigontech/erigon/pull/19468#pullrequestreview-3921956083) - 2026-03-10
+* [Review] [Review on: rpc: add support for debug_setHead](https://github.com/erigontech/erigon/pull/19577#pullrequestreview-3921937114) - 2026-03-10
+* [Review] [Review on: [SharovBot] fix(commitment): count first-nibble branches in CanDoConcurrentNext to fix flaky test](https://github.com/erigontech/erigon/pull/19568#pullrequestreview-3921930148) - 2026-03-10
+* [Review] [Review on: execution/stagedsync: enable deferred commitment updates for parallel fork validation](https://github.com/erigontech/erigon/pull/19749#pullrequestreview-3920128540) - 2026-03-10
+
+[protocolguild/documentation](https://github.com/protocolguild/documentation)
+* [Review] [Review on: Update Erigon contributions with Zilkworm link](https://github.com/protocolguild/documentation/pull/478#pullrequestreview-3923369804) - 2026-03-10
 ## Q4 2025
 
 

--- a/members/yperbasis.md
+++ b/members/yperbasis.md
@@ -13,7 +13,7 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 
 [erigontech/erigon](https://github.com/erigontech/erigon)
 * [Issue] [bal-devnet-3 implementation](https://github.com/erigontech/erigon/issues/18717) - 2026-01-19
-* [Pull Request] []() - 2026-01-22
+* [Pull Request] [execution/vm: fold EVMInterpreter into EVM](https://github.com/erigontech/erigon/pull/18765) - 2026-01-22
 * [Issue] [Erigon built an invalid block on Gnosis Chain](https://github.com/erigontech/erigon/issues/18823) - 2026-01-27
 * [Issue] [deps: update libsecp256k1 to 0.7.1](https://github.com/erigontech/erigon/issues/18822) - 2026-01-27
 * [Issue] [Revisit EIP-6780: merge stateObject.newlyCreated & createdContract?](https://github.com/erigontech/erigon/issues/18808) - 2026-01-26
@@ -28,8 +28,11 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [Improve time of CI jobs and make more checks mandatory for PR merge](https://github.com/erigontech/erigon/issues/19136) - 2026-02-12
 * [Issue] [Implement bal-devnet-2 changes in Caplin](https://github.com/erigontech/erigon/issues/19218) - 2026-02-16
 * [Issue] [Add EIP-7928 Block-level Access Lists JSON RPC methods](https://github.com/erigontech/erigon/issues/19217) - 2026-02-16
-* [Pull Request] []() - 2026-02-19
+* [Pull Request] [execution: small misc RLP improvements](https://github.com/erigontech/erigon/pull/19293) - 2026-02-19
 * [Issue] [Flaky Hive test "Blob Transaction Ordering"](https://github.com/erigontech/erigon/issues/19446) - 2026-02-24
+* [Pull Request] [vm: fix CREATE/CREATE2 collision with EIP-7702 delegated accounts](https://github.com/erigontech/erigon/pull/19777) - 2026-03-10
+* [Pull Request] [txpool: penalize peers sending malformed p2p messages](https://github.com/erigontech/erigon/pull/19781) - 2026-03-10
+* [Commit] [txpool: penalize peers sending malformed p2p messages (#19781)](https://github.com/erigontech/erigon/commit/965cf96a748dc3e3bcd70c2e38a9b47ce64495ac) - 2026-03-10
 ## Q4 2025
 
 
@@ -77,10 +80,10 @@ Team: [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3A
 * [Issue] [Improve directories in `execution`](https://github.com/erigontech/erigon/issues/17689) - 2025-10-27
 * [Issue] [Remove MiningServer](https://github.com/erigontech/erigon/issues/17815) - 2025-11-07
 * [Issue] [Simplify rlp.*ExcludingHead functions](https://github.com/erigontech/erigon/issues/17876) - 2025-11-13
-* [Pull Request] []() - 2025-12-05
-* [Pull Request] []() - 2025-12-23
+* [Pull Request] [execution/rlp: Uint256LenExcludingHead -> Uint256Len](https://github.com/erigontech/erigon/pull/18196) - 2025-12-05
+* [Pull Request] [Remove censoring](https://github.com/erigontech/erigon/pull/18425) - 2025-12-23
 * [Issue] [Flaky TestTraceKey_LargeVals](https://github.com/erigontech/erigon/issues/18493) - 2025-12-29
-* [Pull Request] []() - 2025-12-30
+* [Pull Request] [execution/engineapi: add engine_getBlobsV3](https://github.com/erigontech/erigon/pull/18512) - 2025-12-30
 ## Q3 2025
 
 

--- a/members/zilm13.md
+++ b/members/zilm13.md
@@ -12,18 +12,22 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Azilm13
 
 
 [consensys/teku](https://github.com/consensys/teku)
-* [Pull Request] []() - 2026-01-14
-* [Pull Request] []() - 2026-01-15
-* [Pull Request] []() - 2026-01-16
-* [Pull Request] []() - 2026-01-20
-* [Pull Request] []() - 2026-01-22
-* [Pull Request] []() - 2026-01-23
-* [Pull Request] []() - 2026-01-24
+* [Pull Request] [Add getBlobs blob reconstruction from any 50%](https://github.com/Consensys/teku/pull/10274) - 2026-01-14
+* [Pull Request] [Prefer peer with good response rate](https://github.com/Consensys/teku/pull/10277) - 2026-01-15
+* [Pull Request] [Partition sidecar byRoot batches depending on max blobs](https://github.com/Consensys/teku/pull/10279) - 2026-01-16
+* [Pull Request] [Add sidecars through atomic DB updates](https://github.com/Consensys/teku/pull/10282) - 2026-01-20
+* [Pull Request] [Remove SidecarUpdateChannel.onNewNonCanonicalSidecar(sidecar)](https://github.com/Consensys/teku/pull/10292) - 2026-01-22
+* [Pull Request] [Move error encountered on stream abort to DEBUG level](https://github.com/Consensys/teku/pull/10295) - 2026-01-23
+* [Pull Request] [Add completed slots cache in recovering custody](https://github.com/Consensys/teku/pull/10296) - 2026-01-24
 * [Pull Request] []() - 2026-01-29
-* [Pull Request] []() - 2026-02-03
-* [Pull Request] []() - 2026-02-06
+* [Pull Request] [Add DataColumnSidecarsByRootValidator test](https://github.com/Consensys/teku/pull/10325) - 2026-02-03
+* [Pull Request] [Fulu misc helpers property test](https://github.com/Consensys/teku/pull/10337) - 2026-02-06
 * [Issue] [Penalize peers causing ReqResp/Gossip exceptions](https://github.com/Consensys/teku/issues/10339) - 2026-02-06
 * [Issue] [Archive DataColumnSidecars to the disk](https://github.com/Consensys/teku/issues/10338) - 2026-02-06
+
+[Consensys/teku](https://github.com/Consensys/teku)
+* [Pull Request] [Update DB migration according to the current state (main direction of migration LevelDB -> RocksDB)](https://github.com/Consensys/teku/pull/10471) - 2026-03-10
+* [Commit] [Update according to the current state (main direction of migration LevelDB2 -> RocksDB) (#10471)](https://github.com/Consensys/teku/commit/260d0aeb67951a4f2e6df633966a4e41960a2ce0) - 2026-03-10
 ## Q4 2025
 
 
@@ -31,17 +35,17 @@ Team: [Consensys/teku](https://github.com/Consensys/teku/pulls?q=author%3Azilm13
 * [Commit] [VersionedHashDBSource tests (#9908)](https://github.com/Consensys/teku/commit/2d80867498bbade98ba1e333a60eb8c80a1f8846) - 2025-10-01
 * [Pull Request] [Remove VersionedHashDBSource](https://github.com/Consensys/teku/pull/9964) - 2025-10-02
 * [Pull Request] [Get blobs REST API](https://github.com/Consensys/teku/pull/9978) - 2025-10-07
-* [Pull Request] []() - 2025-10-28
-* [Pull Request] []() - 2025-10-31
+* [Pull Request] [Acceptance Test: Restore DataColumnSidecars from 50%](https://github.com/Consensys/teku/pull/10066) - 2025-10-28
+* [Pull Request] [FULU Checkpoint Sync Acceptance Test](https://github.com/Consensys/teku/pull/10090) - 2025-10-31
 * [Issue] [Store only 1/2 of sidecars on supernodes](https://github.com/Consensys/teku/issues/10095) - 2025-11-03
-* [Pull Request] []() - 2025-11-12
-* [Pull Request] []() - 2025-11-20
-* [Pull Request] []() - 2025-11-26
-* [Pull Request] []() - 2025-11-27
-* [Pull Request] []() - 2025-11-29
-* [Pull Request] []() - 2025-12-09
-* [Pull Request] []() - 2025-12-17
-* [Pull Request] []() - 2025-12-20
+* [Pull Request] [[WIP] Reconstruct supernode sidecars extension](https://github.com/Consensys/teku/pull/10131) - 2025-11-12
+* [Pull Request] [Improve log message in SimpleSidecarRetriever](https://github.com/Consensys/teku/pull/10156) - 2025-11-20
+* [Pull Request] [Fix 50% DAS Recover Acceptance Test flakiness](https://github.com/Consensys/teku/pull/10180) - 2025-11-26
+* [Pull Request] [+1 minute wait time for fulu block reconstruction](https://github.com/Consensys/teku/pull/10182) - 2025-11-27
+* [Pull Request] [Fix sidecars sync](https://github.com/Consensys/teku/pull/10188) - 2025-11-29
+* [Pull Request] [Unify BlobSidecar and Fulu trackers pruning using BlobTrackerPool](https://github.com/Consensys/teku/pull/10215) - 2025-12-09
+* [Pull Request] [Finish DA check on 50% columns](https://github.com/Consensys/teku/pull/10248) - 2025-12-17
+* [Pull Request] [Add User Agent to Builder's headers](https://github.com/Consensys/teku/pull/10255) - 2025-12-20
 * [Pull Request] []() - 2025-12-23
 ## Q3 2025
 


### PR DESCRIPTION
Heya @taxmeifyoucan,
I've noticed a lot of broken entries in the contribution logs of the last quarter.
It looks like github heavily stripped down their usual api, so I've made another version of the contribution tracker that uses the graphql instead.

#9 got closed due to rebase on master.
this PR will cause conflicts with the bad updates of the workflow every day :/